### PR TITLE
[develop] Hilt에서 List 사용 시 발생하는 에러 해결

### DIFF
--- a/app/src/main/java/com/kdjj/ratatouille/di/RepositoryModule.kt
+++ b/app/src/main/java/com/kdjj/ratatouille/di/RepositoryModule.kt
@@ -15,11 +15,9 @@ import dagger.hilt.components.SingletonComponent
 @InstallIn(SingletonComponent::class)
 abstract class RepositoryModule {
 
-//    @Binds
-//    abstract fun provideRecipeRepository(recipeRepositoryImpl: RecipeRepositoryImpl): RecipeRepository
     @Binds
     abstract fun provideSaveRecipeUseCase(saveRecipeUseCase: SaveRecipeUseCase): UseCase<RecipeRequest, Boolean>
-//
-//    @Binds
-//    abstract fun provideFetchRecipeTypesUseCase(fetchRecipeTypesUseCase: FetchRecipeTypesUseCase): UseCase<EmptyRequest, List<RecipeType>>
+
+    @Binds
+    abstract fun provideFetchRecipeTypesUseCase(fetchRecipeTypesUseCase: FetchRecipeTypesUseCase): UseCase<EmptyRequest, List<RecipeType>>
 }

--- a/app/src/main/java/com/kdjj/ratatouille/di/presentation/FakeModule.kt
+++ b/app/src/main/java/com/kdjj/ratatouille/di/presentation/FakeModule.kt
@@ -3,9 +3,6 @@ package com.kdjj.ratatouille.di.presentation
 import com.kdjj.domain.model.Recipe
 import com.kdjj.domain.model.RecipeType
 import com.kdjj.domain.repository.RecipeRepository
-import com.kdjj.domain.request.EmptyRequest
-import com.kdjj.domain.usecase.FetchRecipeTypesUseCase
-import com.kdjj.domain.usecase.UseCase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -28,10 +25,5 @@ class FakeModule {
                 TODO("Not yet implemented")
             }
         }
-    }
-
-    @Provides
-    fun provideFetchRecipeTypesUseCase(repository: RecipeRepository): UseCase<EmptyRequest, List<RecipeType>> {
-        return FetchRecipeTypesUseCase(repository)
     }
 }

--- a/domain/src/main/java/com/kdjj/domain/usecase/FetchRecipeTypesUseCase.kt
+++ b/domain/src/main/java/com/kdjj/domain/usecase/FetchRecipeTypesUseCase.kt
@@ -7,7 +7,7 @@ import javax.inject.Inject
 
 class FetchRecipeTypesUseCase @Inject constructor(
     private val recipeRepository: RecipeRepository
-) : UseCase<EmptyRequest, List<RecipeType>> {
+) : UseCase<EmptyRequest, @JvmSuppressWildcards List<RecipeType>> {
 
     override suspend fun invoke(request: EmptyRequest): Result<List<RecipeType>> =
         recipeRepository.fetchRecipeTypes()


### PR DESCRIPTION
### 관련 이슈 #25 

- Hilt에서 List를 그냥 사용하면 Kotlin List의 제너릭 타입 `<out E>` 때문에 에러 발생
- `@JvmSuppressWildcards`를 사용하여 자바 코드가 생성될 때 <? extends> 가 붙지 않도록 함