### PR TITLE
[develop] 서버 레시피 리스트 로드 ( domain, data, remote ) 

### DIFF
--- a/app/src/main/java/com/kdjj/ratatouille/di/data/RecipeListModule.kt
+++ b/app/src/main/java/com/kdjj/ratatouille/di/data/RecipeListModule.kt
@@ -1,0 +1,30 @@
+package com.kdjj.ratatouille.di.data
+
+import com.kdjj.data.datasource.RecipeListRemoteDataSource
+import com.kdjj.data.repository.RecipeListRepositoryImpl
+import com.kdjj.domain.repository.RecipeListRepository
+import com.kdjj.remote.dao.RecipeListDao
+import com.kdjj.remote.dao.RecipeListDaoImpl
+import com.kdjj.remote.datasource.RecipeListRemoteDataSourceImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class RecipeListModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindRecipeListRepository(recipeListRepositoryImpl: RecipeListRepositoryImpl): RecipeListRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindRecipeListRemoteDataSource(recipeListRemoteDataSourceImpl: RecipeListRemoteDataSourceImpl): RecipeListRemoteDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindRecipeListDao(recipeListDaoImpl: RecipeListDaoImpl): RecipeListDao
+}

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -13,5 +13,6 @@ dependencies {
     implementation "com.google.dagger:dagger:$dagger_version"
     implementation "com.google.dagger:dagger-android:$dagger_version"
     kapt "com.google.dagger:dagger-compiler:$dagger_version"
+
     implementation project(path: ':domain')
 }

--- a/data/src/main/java/com/kdjj/data/datasource/RecipeListRemoteDataSource.kt
+++ b/data/src/main/java/com/kdjj/data/datasource/RecipeListRemoteDataSource.kt
@@ -4,5 +4,5 @@ import com.kdjj.domain.model.Recipe
 
 interface RecipeListRemoteDataSource {
 
-    suspend fun fetchLatestRecipeList(lastVisibleCreateTime: Long): Result<List<Recipe>>
+    suspend fun fetchLatestRecipeListAfter(lastVisibleCreateTime: Long): Result<List<Recipe>>
 }

--- a/data/src/main/java/com/kdjj/data/datasource/RecipeListRemoteDataSource.kt
+++ b/data/src/main/java/com/kdjj/data/datasource/RecipeListRemoteDataSource.kt
@@ -1,0 +1,8 @@
+package com.kdjj.data.datasource
+
+import com.kdjj.domain.model.Recipe
+
+interface RecipeListRemoteDataSource {
+
+    suspend fun fetchLatestRecipeList(): Result<List<Recipe>>
+}

--- a/data/src/main/java/com/kdjj/data/datasource/RecipeListRemoteDataSource.kt
+++ b/data/src/main/java/com/kdjj/data/datasource/RecipeListRemoteDataSource.kt
@@ -4,5 +4,5 @@ import com.kdjj.domain.model.Recipe
 
 interface RecipeListRemoteDataSource {
 
-    suspend fun fetchLatestRecipeList(): Result<List<Recipe>>
+    suspend fun fetchLatestRecipeList(lastVisibleCreateTime: Long): Result<List<Recipe>>
 }

--- a/data/src/main/java/com/kdjj/data/datasource/RecipeListRemoteDataSource.kt
+++ b/data/src/main/java/com/kdjj/data/datasource/RecipeListRemoteDataSource.kt
@@ -5,4 +5,6 @@ import com.kdjj.domain.model.Recipe
 interface RecipeListRemoteDataSource {
 
     suspend fun fetchLatestRecipeListAfter(lastVisibleCreateTime: Long): Result<List<Recipe>>
+
+    suspend fun fetchPopularRecipeListAfter(lastVisibleViewCount: Int): Result<List<Recipe>>
 }

--- a/data/src/main/java/com/kdjj/data/datasource/RecipeListRemoteDataSource.kt
+++ b/data/src/main/java/com/kdjj/data/datasource/RecipeListRemoteDataSource.kt
@@ -7,4 +7,6 @@ interface RecipeListRemoteDataSource {
     suspend fun fetchLatestRecipeListAfter(lastVisibleCreateTime: Long): Result<List<Recipe>>
 
     suspend fun fetchPopularRecipeListAfter(lastVisibleViewCount: Int): Result<List<Recipe>>
+
+    suspend fun fetchSearchRecipeListAfter(keyword: String, lastVisibleTitle: String): Result<List<Recipe>>
 }

--- a/data/src/main/java/com/kdjj/data/repository/RecipeListRepositoryImpl.kt
+++ b/data/src/main/java/com/kdjj/data/repository/RecipeListRepositoryImpl.kt
@@ -9,6 +9,6 @@ class RecipeListRepositoryImpl @Inject constructor(
     private val recipeListRemoteDataSource: RecipeListRemoteDataSource,
 ) : RecipeListRepository {
 
-    override suspend fun fetchRemoteLatestRecipeList(): Result<List<Recipe>> =
-        recipeListRemoteDataSource.fetchLatestRecipeList()
+    override suspend fun fetchRemoteLatestRecipeList(lastVisibleCreateTime: Long): Result<List<Recipe>> =
+        recipeListRemoteDataSource.fetchLatestRecipeList(lastVisibleCreateTime)
 }

--- a/data/src/main/java/com/kdjj/data/repository/RecipeListRepositoryImpl.kt
+++ b/data/src/main/java/com/kdjj/data/repository/RecipeListRepositoryImpl.kt
@@ -14,4 +14,11 @@ class RecipeListRepositoryImpl @Inject constructor(
 
     override suspend fun fetchRemotePopularRecipeListAfter(lastVisibleViewCount: Int): Result<List<Recipe>> =
         recipeListRemoteDataSource.fetchPopularRecipeListAfter(lastVisibleViewCount)
+
+    override suspend fun fetchRemoteSearchRecipeListAfter(
+        keyword: String,
+        lastVisibleTitle: String
+    ): Result<List<Recipe>> =
+        recipeListRemoteDataSource.fetchSearchRecipeListAfter(keyword, lastVisibleTitle)
+
 }

--- a/data/src/main/java/com/kdjj/data/repository/RecipeListRepositoryImpl.kt
+++ b/data/src/main/java/com/kdjj/data/repository/RecipeListRepositoryImpl.kt
@@ -1,0 +1,14 @@
+package com.kdjj.data.repository
+
+import com.kdjj.data.datasource.RecipeListRemoteDataSource
+import com.kdjj.domain.model.Recipe
+import com.kdjj.domain.repository.RecipeListRepository
+import javax.inject.Inject
+
+class RecipeListRepositoryImpl @Inject constructor(
+    private val recipeListRemoteDataSource: RecipeListRemoteDataSource,
+) : RecipeListRepository {
+
+    override suspend fun fetchRemoteLatestRecipeList(): Result<List<Recipe>> =
+        recipeListRemoteDataSource.fetchLatestRecipeList()
+}

--- a/data/src/main/java/com/kdjj/data/repository/RecipeListRepositoryImpl.kt
+++ b/data/src/main/java/com/kdjj/data/repository/RecipeListRepositoryImpl.kt
@@ -11,4 +11,7 @@ class RecipeListRepositoryImpl @Inject constructor(
 
     override suspend fun fetchRemoteLatestRecipeListAfter(lastVisibleCreateTime: Long): Result<List<Recipe>> =
         recipeListRemoteDataSource.fetchLatestRecipeListAfter(lastVisibleCreateTime)
+
+    override suspend fun fetchRemotePopularRecipeListAfter(lastVisibleViewCount: Int): Result<List<Recipe>> =
+        recipeListRemoteDataSource.fetchPopularRecipeListAfter(lastVisibleViewCount)
 }

--- a/data/src/main/java/com/kdjj/data/repository/RecipeListRepositoryImpl.kt
+++ b/data/src/main/java/com/kdjj/data/repository/RecipeListRepositoryImpl.kt
@@ -9,6 +9,6 @@ class RecipeListRepositoryImpl @Inject constructor(
     private val recipeListRemoteDataSource: RecipeListRemoteDataSource,
 ) : RecipeListRepository {
 
-    override suspend fun fetchRemoteLatestRecipeList(lastVisibleCreateTime: Long): Result<List<Recipe>> =
-        recipeListRemoteDataSource.fetchLatestRecipeList(lastVisibleCreateTime)
+    override suspend fun fetchRemoteLatestRecipeListAfter(lastVisibleCreateTime: Long): Result<List<Recipe>> =
+        recipeListRemoteDataSource.fetchLatestRecipeListAfter(lastVisibleCreateTime)
 }

--- a/domain/src/main/java/com/kdjj/domain/repository/RecipeListRepository.kt
+++ b/domain/src/main/java/com/kdjj/domain/repository/RecipeListRepository.kt
@@ -4,5 +4,5 @@ import com.kdjj.domain.model.Recipe
 
 interface RecipeListRepository {
 
-    suspend fun fetchRemoteLatestRecipeList(): Result<List<Recipe>>
+    suspend fun fetchRemoteLatestRecipeList(lastVisibleCreateTime: Long): Result<List<Recipe>>
 }

--- a/domain/src/main/java/com/kdjj/domain/repository/RecipeListRepository.kt
+++ b/domain/src/main/java/com/kdjj/domain/repository/RecipeListRepository.kt
@@ -5,4 +5,6 @@ import com.kdjj.domain.model.Recipe
 interface RecipeListRepository {
 
     suspend fun fetchRemoteLatestRecipeListAfter(lastVisibleCreateTime: Long): Result<List<Recipe>>
+
+    suspend fun fetchRemotePopularRecipeListAfter(lastVisibleViewCount: Int): Result<List<Recipe>>
 }

--- a/domain/src/main/java/com/kdjj/domain/repository/RecipeListRepository.kt
+++ b/domain/src/main/java/com/kdjj/domain/repository/RecipeListRepository.kt
@@ -1,0 +1,8 @@
+package com.kdjj.domain.repository
+
+import com.kdjj.domain.model.Recipe
+
+interface RecipeListRepository {
+
+    suspend fun fetchRemoteLatestRecipeList(): Result<List<Recipe>>
+}

--- a/domain/src/main/java/com/kdjj/domain/repository/RecipeListRepository.kt
+++ b/domain/src/main/java/com/kdjj/domain/repository/RecipeListRepository.kt
@@ -7,4 +7,6 @@ interface RecipeListRepository {
     suspend fun fetchRemoteLatestRecipeListAfter(lastVisibleCreateTime: Long): Result<List<Recipe>>
 
     suspend fun fetchRemotePopularRecipeListAfter(lastVisibleViewCount: Int): Result<List<Recipe>>
+
+    suspend fun fetchRemoteSearchRecipeListAfter(keyword: String, lastVisibleTitle: String): Result<List<Recipe>>
 }

--- a/domain/src/main/java/com/kdjj/domain/repository/RecipeListRepository.kt
+++ b/domain/src/main/java/com/kdjj/domain/repository/RecipeListRepository.kt
@@ -4,5 +4,5 @@ import com.kdjj.domain.model.Recipe
 
 interface RecipeListRepository {
 
-    suspend fun fetchRemoteLatestRecipeList(lastVisibleCreateTime: Long): Result<List<Recipe>>
+    suspend fun fetchRemoteLatestRecipeListAfter(lastVisibleCreateTime: Long): Result<List<Recipe>>
 }

--- a/domain/src/main/java/com/kdjj/domain/request/FetchRemoteLatestRecipeListRequest.kt
+++ b/domain/src/main/java/com/kdjj/domain/request/FetchRemoteLatestRecipeListRequest.kt
@@ -1,0 +1,5 @@
+package com.kdjj.domain.request
+
+data class FetchRemoteLatestRecipeListRequest(
+    val lastVisibleCreateTime: Long,
+) : Request

--- a/domain/src/main/java/com/kdjj/domain/request/FetchRemotePopularRecipeListRequest.kt
+++ b/domain/src/main/java/com/kdjj/domain/request/FetchRemotePopularRecipeListRequest.kt
@@ -1,5 +1,5 @@
 package com.kdjj.domain.request
 
-data class FetchRemotePopularRecipeListRequset(
+data class FetchRemotePopularRecipeListRequest(
     val lastVisibleViewCount: Int,
 ) : Request

--- a/domain/src/main/java/com/kdjj/domain/request/FetchRemotePopularRecipeListRequset.kt
+++ b/domain/src/main/java/com/kdjj/domain/request/FetchRemotePopularRecipeListRequset.kt
@@ -1,0 +1,5 @@
+package com.kdjj.domain.request
+
+data class FetchRemotePopularRecipeListRequset(
+    val lastVisibleViewCount: Int,
+) : Request

--- a/domain/src/main/java/com/kdjj/domain/request/FetchRemoteSearchRecipeListRequest.kt
+++ b/domain/src/main/java/com/kdjj/domain/request/FetchRemoteSearchRecipeListRequest.kt
@@ -2,4 +2,5 @@ package com.kdjj.domain.request
 
 data class FetchRemoteSearchRecipeListRequest(
     val keyword: String,
+    val lastVisibleTitle: String,
 ) : Request

--- a/domain/src/main/java/com/kdjj/domain/request/FetchRemoteSearchRecipeListRequest.kt
+++ b/domain/src/main/java/com/kdjj/domain/request/FetchRemoteSearchRecipeListRequest.kt
@@ -1,0 +1,5 @@
+package com.kdjj.domain.request
+
+data class FetchRemoteSearchRecipeListRequest(
+    val keyword: String,
+) : Request

--- a/domain/src/main/java/com/kdjj/domain/usecase/FetchRemoteLatestRecipeListUseCase.kt
+++ b/domain/src/main/java/com/kdjj/domain/usecase/FetchRemoteLatestRecipeListUseCase.kt
@@ -1,0 +1,14 @@
+package com.kdjj.domain.usecase
+
+import com.kdjj.domain.model.Recipe
+import com.kdjj.domain.repository.RecipeListRepository
+import com.kdjj.domain.request.EmptyRequest
+import javax.inject.Inject
+
+class FetchRemoteLatestRecipeListUseCase @Inject constructor(
+    private val recipeListRepository: RecipeListRepository
+) : UseCase<EmptyRequest, @JvmSuppressWildcards List<Recipe>> {
+
+    override suspend fun invoke(request: EmptyRequest): Result<List<Recipe>> =
+        recipeListRepository.fetchRemoteLatestRecipeList()
+}

--- a/domain/src/main/java/com/kdjj/domain/usecase/FetchRemoteLatestRecipeListUseCase.kt
+++ b/domain/src/main/java/com/kdjj/domain/usecase/FetchRemoteLatestRecipeListUseCase.kt
@@ -10,5 +10,5 @@ class FetchRemoteLatestRecipeListUseCase @Inject constructor(
 ) : UseCase<FetchRemoteLatestRecipeListRequest, @JvmSuppressWildcards List<Recipe>> {
 
     override suspend fun invoke(request: FetchRemoteLatestRecipeListRequest): Result<List<Recipe>> =
-        recipeListRepository.fetchRemoteLatestRecipeList(request.lastVisibleCreateTime)
+        recipeListRepository.fetchRemoteLatestRecipeListAfter(request.lastVisibleCreateTime)
 }

--- a/domain/src/main/java/com/kdjj/domain/usecase/FetchRemoteLatestRecipeListUseCase.kt
+++ b/domain/src/main/java/com/kdjj/domain/usecase/FetchRemoteLatestRecipeListUseCase.kt
@@ -2,13 +2,13 @@ package com.kdjj.domain.usecase
 
 import com.kdjj.domain.model.Recipe
 import com.kdjj.domain.repository.RecipeListRepository
-import com.kdjj.domain.request.EmptyRequest
+import com.kdjj.domain.request.FetchRemoteLatestRecipeListRequest
 import javax.inject.Inject
 
 class FetchRemoteLatestRecipeListUseCase @Inject constructor(
     private val recipeListRepository: RecipeListRepository
-) : UseCase<EmptyRequest, @JvmSuppressWildcards List<Recipe>> {
+) : UseCase<FetchRemoteLatestRecipeListRequest, @JvmSuppressWildcards List<Recipe>> {
 
-    override suspend fun invoke(request: EmptyRequest): Result<List<Recipe>> =
-        recipeListRepository.fetchRemoteLatestRecipeList()
+    override suspend fun invoke(request: FetchRemoteLatestRecipeListRequest): Result<List<Recipe>> =
+        recipeListRepository.fetchRemoteLatestRecipeList(request.lastVisibleCreateTime)
 }

--- a/domain/src/main/java/com/kdjj/domain/usecase/FetchRemotePopularRecipeListUseCase.kt
+++ b/domain/src/main/java/com/kdjj/domain/usecase/FetchRemotePopularRecipeListUseCase.kt
@@ -2,13 +2,13 @@ package com.kdjj.domain.usecase
 
 import com.kdjj.domain.model.Recipe
 import com.kdjj.domain.repository.RecipeListRepository
-import com.kdjj.domain.request.FetchRemotePopularRecipeListRequset
+import com.kdjj.domain.request.FetchRemotePopularRecipeListRequest
 import javax.inject.Inject
 
 class FetchRemotePopularRecipeListUseCase @Inject constructor(
     private val recipeListRepository: RecipeListRepository
-) : UseCase<FetchRemotePopularRecipeListRequset, @JvmSuppressWildcards List<Recipe>>{
+) : UseCase<FetchRemotePopularRecipeListRequest, @JvmSuppressWildcards List<Recipe>>{
 
-    override suspend fun invoke(request: FetchRemotePopularRecipeListRequset): Result<List<Recipe>> =
+    override suspend fun invoke(request: FetchRemotePopularRecipeListRequest): Result<List<Recipe>> =
         recipeListRepository.fetchRemotePopularRecipeListAfter(request.lastVisibleViewCount)
 }

--- a/domain/src/main/java/com/kdjj/domain/usecase/FetchRemotePopularRecipeListUseCase.kt
+++ b/domain/src/main/java/com/kdjj/domain/usecase/FetchRemotePopularRecipeListUseCase.kt
@@ -1,0 +1,14 @@
+package com.kdjj.domain.usecase
+
+import com.kdjj.domain.model.Recipe
+import com.kdjj.domain.repository.RecipeListRepository
+import com.kdjj.domain.request.FetchRemotePopularRecipeListRequset
+import javax.inject.Inject
+
+class FetchRemotePopularRecipeListUseCase @Inject constructor(
+    private val recipeListRepository: RecipeListRepository
+) : UseCase<FetchRemotePopularRecipeListRequset, @JvmSuppressWildcards List<Recipe>>{
+
+    override suspend fun invoke(request: FetchRemotePopularRecipeListRequset): Result<List<Recipe>> =
+        recipeListRepository.fetchRemotePopularRecipeListAfter(request.lastVisibleViewCount)
+}

--- a/domain/src/main/java/com/kdjj/domain/usecase/FetchRemoteSearchRecipeListUseCase.kt
+++ b/domain/src/main/java/com/kdjj/domain/usecase/FetchRemoteSearchRecipeListUseCase.kt
@@ -1,0 +1,14 @@
+package com.kdjj.domain.usecase
+
+import com.kdjj.domain.model.Recipe
+import com.kdjj.domain.repository.RecipeListRepository
+import com.kdjj.domain.request.FetchRemoteSearchRecipeListRequest
+import javax.inject.Inject
+
+class FetchRemoteSearchRecipeListUseCase @Inject constructor(
+    private val recipeListRepository: RecipeListRepository,
+): UseCase<FetchRemoteSearchRecipeListRequest, @JvmSuppressWildcards List<Recipe>>{
+
+    override suspend fun invoke(request: FetchRemoteSearchRecipeListRequest): Result<List<Recipe>> =
+        recipeListRepository.fetchRemoteSearchRecipeListAfter(request.keyword, request.lastVisibleTitle)
+}

--- a/remote/src/main/java/com/kdjj/remote/dao/RecipeListDao.kt
+++ b/remote/src/main/java/com/kdjj/remote/dao/RecipeListDao.kt
@@ -5,4 +5,6 @@ import com.kdjj.domain.model.Recipe
 interface RecipeListDao {
 
     suspend fun fetchLatestRecipeListAfter(lastVisibleCreateTime: Long): List<Recipe>
+
+    suspend fun fetchPopularRecipeListAfter(lastVisibleViewCount: Int): List<Recipe>
 }

--- a/remote/src/main/java/com/kdjj/remote/dao/RecipeListDao.kt
+++ b/remote/src/main/java/com/kdjj/remote/dao/RecipeListDao.kt
@@ -4,5 +4,5 @@ import com.kdjj.domain.model.Recipe
 
 interface RecipeListDao {
 
-    suspend fun fetchLatestRecipeList(): List<Recipe>
+    suspend fun fetchLatestRecipeList(lastVisibleCreateTime: Long): List<Recipe>
 }

--- a/remote/src/main/java/com/kdjj/remote/dao/RecipeListDao.kt
+++ b/remote/src/main/java/com/kdjj/remote/dao/RecipeListDao.kt
@@ -1,0 +1,8 @@
+package com.kdjj.remote.dao
+
+import com.kdjj.domain.model.Recipe
+
+interface RecipeListDao {
+
+    suspend fun fetchLatestRecipeList(): List<Recipe>
+}

--- a/remote/src/main/java/com/kdjj/remote/dao/RecipeListDao.kt
+++ b/remote/src/main/java/com/kdjj/remote/dao/RecipeListDao.kt
@@ -7,4 +7,6 @@ interface RecipeListDao {
     suspend fun fetchLatestRecipeListAfter(lastVisibleCreateTime: Long): List<Recipe>
 
     suspend fun fetchPopularRecipeListAfter(lastVisibleViewCount: Int): List<Recipe>
+
+    suspend fun fetchSearchRecipeListAfter(keyword: String, lastVisibleTitle: String): List<Recipe>
 }

--- a/remote/src/main/java/com/kdjj/remote/dao/RecipeListDao.kt
+++ b/remote/src/main/java/com/kdjj/remote/dao/RecipeListDao.kt
@@ -4,5 +4,5 @@ import com.kdjj.domain.model.Recipe
 
 interface RecipeListDao {
 
-    suspend fun fetchLatestRecipeList(lastVisibleCreateTime: Long): List<Recipe>
+    suspend fun fetchLatestRecipeListAfter(lastVisibleCreateTime: Long): List<Recipe>
 }

--- a/remote/src/main/java/com/kdjj/remote/dao/RecipeListDaoImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/dao/RecipeListDaoImpl.kt
@@ -33,6 +33,18 @@ class RecipeListDaoImpl @Inject constructor(
                 }
         }
 
+    override suspend fun fetchPopularRecipeListAfter(lastVisibleViewCount: Int): List<Recipe> =
+        withContext(Dispatchers.IO) {
+            firestore.collection(RECIPE_COLLECTION_ID)
+                .orderBy(PAGE_ORDER_BY, Query.Direction.DESCENDING)
+                .startAfter(lastVisibleViewCount)
+                .limit(PAGING_SIZE)
+                .get()
+                .await()
+                .map { queryDocumentSnapshot ->
+                    entityToDomain(queryDocumentSnapshot.toObject<RecipeEntity>())
+                }
+        }
 
     companion object {
         const val PAGE_ORDER_BY = "createTime"

--- a/remote/src/main/java/com/kdjj/remote/dao/RecipeListDaoImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/dao/RecipeListDaoImpl.kt
@@ -1,0 +1,34 @@
+package com.kdjj.remote.dao
+
+import android.util.Log
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.ktx.toObject
+import com.kdjj.domain.model.Recipe
+import com.kdjj.remote.entity.RecipeEntity
+import com.kdjj.remote.entity.RecipeTypeEntity
+import com.kdjj.remote.entityToDomain
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class RecipeListDaoImpl @Inject constructor(
+    private val firestore: FirebaseFirestore
+) : RecipeListDao {
+
+    override suspend fun fetchLatestRecipeList(): List<Recipe> =
+        withContext(Dispatchers.IO) {
+            firestore.collection(RECIPE_COLLECTION_ID)
+                .get()
+                .await()
+                .map { queryDocumentSnapshot ->
+                    entityToDomain(queryDocumentSnapshot.toObject<RecipeEntity>())
+                }
+        }
+
+
+    companion object {
+
+        const val RECIPE_COLLECTION_ID = "recipe"
+    }
+}

--- a/remote/src/main/java/com/kdjj/remote/dao/RecipeListDaoImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/dao/RecipeListDaoImpl.kt
@@ -1,6 +1,7 @@
 package com.kdjj.remote.dao
 
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Query
 import com.google.firebase.firestore.ktx.toObject
 import com.kdjj.domain.model.Recipe
 import com.kdjj.remote.entity.RecipeEntity
@@ -19,10 +20,10 @@ class RecipeListDaoImpl @Inject constructor(
     더 이상 가져올 페이지 없으면 emptyList 리턴 함
     Room 과 달리 query  orderby limit offset  으로 paging 처리가 안 됨 , firestore에서 offset을 지원하지 않음
      */
-    override suspend fun fetchLatestRecipeList(lastVisibleCreateTime: Long): List<Recipe> =
+    override suspend fun fetchLatestRecipeListAfter(lastVisibleCreateTime: Long): List<Recipe> =
         withContext(Dispatchers.IO) {
             firestore.collection(RECIPE_COLLECTION_ID)
-                .orderBy(PAGE_ORDER_BY)
+                .orderBy(PAGE_ORDER_BY, Query.Direction.DESCENDING)
                 .startAfter(lastVisibleCreateTime)
                 .limit(PAGING_SIZE)
                 .get()

--- a/remote/src/main/java/com/kdjj/remote/dao/RecipeListDaoImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/dao/RecipeListDaoImpl.kt
@@ -23,7 +23,7 @@ class RecipeListDaoImpl @Inject constructor(
     override suspend fun fetchLatestRecipeListAfter(lastVisibleCreateTime: Long): List<Recipe> =
         withContext(Dispatchers.IO) {
             firestore.collection(RECIPE_COLLECTION_ID)
-                .orderBy(PAGE_ORDER_BY, Query.Direction.DESCENDING)
+                .orderBy(FIELD_CREATE_TIME, Query.Direction.DESCENDING)
                 .startAfter(lastVisibleCreateTime)
                 .limit(PAGING_SIZE)
                 .get()
@@ -36,7 +36,7 @@ class RecipeListDaoImpl @Inject constructor(
     override suspend fun fetchPopularRecipeListAfter(lastVisibleViewCount: Int): List<Recipe> =
         withContext(Dispatchers.IO) {
             firestore.collection(RECIPE_COLLECTION_ID)
-                .orderBy(PAGE_ORDER_BY, Query.Direction.DESCENDING)
+                .orderBy(FIELD_VIEW_COUNT, Query.Direction.DESCENDING)
                 .startAfter(lastVisibleViewCount)
                 .limit(PAGING_SIZE)
                 .get()
@@ -47,7 +47,8 @@ class RecipeListDaoImpl @Inject constructor(
         }
 
     companion object {
-        const val PAGE_ORDER_BY = "createTime"
+        const val FIELD_CREATE_TIME = "createTime"
+        const val FIELD_VIEW_COUNT = "viewCount"
         const val RECIPE_COLLECTION_ID = "recipe"
         const val PAGING_SIZE = 10L
     }

--- a/remote/src/main/java/com/kdjj/remote/dao/RecipeListDaoImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/dao/RecipeListDaoImpl.kt
@@ -1,11 +1,9 @@
 package com.kdjj.remote.dao
 
-import android.util.Log
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ktx.toObject
 import com.kdjj.domain.model.Recipe
 import com.kdjj.remote.entity.RecipeEntity
-import com.kdjj.remote.entity.RecipeTypeEntity
 import com.kdjj.remote.entityToDomain
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.tasks.await
@@ -16,9 +14,17 @@ class RecipeListDaoImpl @Inject constructor(
     private val firestore: FirebaseFirestore
 ) : RecipeListDao {
 
-    override suspend fun fetchLatestRecipeList(): List<Recipe> =
+    /*
+    first page 가져올때 lastVisibleCreateTime에 0 넣으면 맨 앞에서 부터 page Size 만큼 가져옴
+    더 이상 가져올 페이지 없으면 emptyList 리턴 함
+    Room 과 달리 query  orderby limit offset  으로 paging 처리가 안 됨 , firestore에서 offset을 지원하지 않음
+     */
+    override suspend fun fetchLatestRecipeList(lastVisibleCreateTime: Long): List<Recipe> =
         withContext(Dispatchers.IO) {
             firestore.collection(RECIPE_COLLECTION_ID)
+                .orderBy(PAGE_ORDER_BY)
+                .startAfter(lastVisibleCreateTime)
+                .limit(PAGING_SIZE)
                 .get()
                 .await()
                 .map { queryDocumentSnapshot ->
@@ -28,7 +34,8 @@ class RecipeListDaoImpl @Inject constructor(
 
 
     companion object {
-
+        const val PAGE_ORDER_BY = "createTime"
         const val RECIPE_COLLECTION_ID = "recipe"
+        const val PAGING_SIZE = 10L
     }
 }

--- a/remote/src/main/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImpl.kt
@@ -24,5 +24,4 @@ class RecipeListRemoteDataSourceImpl @Inject constructor(
         } catch (e: Exception) {
             Result.failure(e)
         }
-
 }

--- a/remote/src/main/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImpl.kt
@@ -1,0 +1,18 @@
+package com.kdjj.remote.datasource
+
+import com.kdjj.data.datasource.RecipeListRemoteDataSource
+import com.kdjj.domain.model.Recipe
+import com.kdjj.remote.dao.RecipeListDao
+import javax.inject.Inject
+
+class RecipeListRemoteDataSourceImpl @Inject constructor(
+    private val recipeListDao: RecipeListDao,
+) : RecipeListRemoteDataSource {
+    override suspend fun fetchLatestRecipeList(): Result<List<Recipe>> =
+        try {
+            val recipeList = recipeListDao.fetchLatestRecipeList()
+            Result.success(recipeList)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+}

--- a/remote/src/main/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImpl.kt
@@ -24,4 +24,16 @@ class RecipeListRemoteDataSourceImpl @Inject constructor(
         } catch (e: Exception) {
             Result.failure(e)
         }
+
+    override suspend fun fetchSearchRecipeListAfter(
+        keyword: String,
+        lastVisibleTitle: String
+    ): Result<List<Recipe>> =
+        try {
+            val recipeList = recipeListDao.fetchSearchRecipeListAfter(keyword, lastVisibleTitle)
+            Result.success(recipeList)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+
 }

--- a/remote/src/main/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImpl.kt
@@ -8,9 +8,9 @@ import javax.inject.Inject
 class RecipeListRemoteDataSourceImpl @Inject constructor(
     private val recipeListDao: RecipeListDao,
 ) : RecipeListRemoteDataSource {
-    override suspend fun fetchLatestRecipeList(): Result<List<Recipe>> =
+    override suspend fun fetchLatestRecipeList(lastVisibleCreateTime: Long): Result<List<Recipe>> =
         try {
-            val recipeList = recipeListDao.fetchLatestRecipeList()
+            val recipeList = recipeListDao.fetchLatestRecipeList(lastVisibleCreateTime)
             Result.success(recipeList)
         } catch (e: Exception) {
             Result.failure(e)

--- a/remote/src/main/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImpl.kt
@@ -8,6 +8,7 @@ import javax.inject.Inject
 class RecipeListRemoteDataSourceImpl @Inject constructor(
     private val recipeListDao: RecipeListDao,
 ) : RecipeListRemoteDataSource {
+
     override suspend fun fetchLatestRecipeListAfter(lastVisibleCreateTime: Long): Result<List<Recipe>> =
         try {
             val recipeList = recipeListDao.fetchLatestRecipeListAfter(lastVisibleCreateTime)
@@ -15,4 +16,13 @@ class RecipeListRemoteDataSourceImpl @Inject constructor(
         } catch (e: Exception) {
             Result.failure(e)
         }
+
+    override suspend fun fetchPopularRecipeListAfter(lastVisibleViewCount: Int): Result<List<Recipe>> =
+        try {
+            val recipeList = recipeListDao.fetchPopularRecipeListAfter(lastVisibleViewCount)
+            Result.success(recipeList)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+
 }

--- a/remote/src/main/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImpl.kt
@@ -8,9 +8,9 @@ import javax.inject.Inject
 class RecipeListRemoteDataSourceImpl @Inject constructor(
     private val recipeListDao: RecipeListDao,
 ) : RecipeListRemoteDataSource {
-    override suspend fun fetchLatestRecipeList(lastVisibleCreateTime: Long): Result<List<Recipe>> =
+    override suspend fun fetchLatestRecipeListAfter(lastVisibleCreateTime: Long): Result<List<Recipe>> =
         try {
-            val recipeList = recipeListDao.fetchLatestRecipeList(lastVisibleCreateTime)
+            val recipeList = recipeListDao.fetchLatestRecipeListAfter(lastVisibleCreateTime)
             Result.success(recipeList)
         } catch (e: Exception) {
             Result.failure(e)


### PR DESCRIPTION
## 페이징 처리 
704b3a84281a3f72758eebf8880ca903fb64b1c2
presentation 에서 페이징 처리 할 때 참고해주세요 .
Room 과 달리 query  orderby limit offset  으로 paging 처리가 안 됩니다.( firestore에서 offset을 지원하지 않음 ) 
```kotlin
firestore.collection(RECIPE_COLLECTION_ID)
        .orderBy(FIELD_CREATE_TIME, Query.Direction.DESCENDING)
        .startAfter(lastVisibleCreateTime)
        .limit(PAGING_SIZE)
        .get()
        .await()
        .map { queryDocumentSnapshot ->
            entityToDomain(queryDocumentSnapshot.toObject<RecipeEntity>())
        }
```
first page 가져올때 lastVisibleCreateTime에 0 넣으면 맨 앞에서 부터 page Size 만큼 가져옵니다! 
lastVisible... 이 String 일땐 empty String 넣어주면 됩니다. 
더 이상 가져올게 없는 경우 emptyList 리턴 합니다. 

## 검색 이슈
2435b046b9d0d71f0593abdb710e8bbfa164452c
discussion 참고해주세요.
https://github.com/boostcampwm-2021/Android08-Ratatouille/discussions/47
