### PR TITLE
[develop] SaveRecipeUseCase 레시피 이미지 저장하는 로직 추가 #73

### DIFF
--- a/domain/src/main/java/com/kdjj/domain/usecase/SaveRecipeUseCase.kt
+++ b/domain/src/main/java/com/kdjj/domain/usecase/SaveRecipeUseCase.kt
@@ -1,13 +1,48 @@
 package com.kdjj.domain.usecase
 
+import com.kdjj.domain.repository.RecipeImageRepository
 import com.kdjj.domain.repository.RecipeRepository
 import com.kdjj.domain.request.SaveRecipeRequest
 import javax.inject.Inject
 
 internal class SaveRecipeUseCase @Inject constructor(
-    private val recipeRepository: RecipeRepository
+    private val recipeRepository: RecipeRepository,
+    private val imageRepository: RecipeImageRepository
 ) : UseCase<SaveRecipeRequest, Boolean> {
     
     override suspend fun invoke(request: SaveRecipeRequest): Result<Boolean> =
-        recipeRepository.saveRecipe(request.recipe)
+        kotlin.runCatching {
+            val recipe = request.recipe
+            val recipeImageUri = when (recipe.imgPath.isNotEmpty()) {
+                true -> {
+                    val recipeImageByteArray =
+                        imageRepository.convertLocalUriToByteArray(recipe.imgPath).getOrThrow()
+                    imageRepository.convertByteArrayToLocalStorageUri(
+                        recipeImageByteArray, recipe.recipeId
+                    ).getOrThrow()
+                }
+                false -> ""
+            }
+            val recipeStepList = recipe.stepList.map { step ->
+                val stepImageUri = when (step.imgPath.isNotEmpty()) {
+                    true -> {
+                        val stepImageByteArray =
+                            imageRepository.convertLocalUriToByteArray(step.imgPath).getOrThrow()
+                        imageRepository.convertByteArrayToLocalStorageUri(
+                            stepImageByteArray, step.stepId
+                        ).getOrThrow()
+                    }
+                    false -> ""
+                }
+                step.copy(imgPath = stepImageUri)
+            }
+            
+            recipeRepository.saveRecipe(
+                recipe.copy(
+                    imgPath = recipeImageUri,
+                    stepList = recipeStepList
+                )
+            )
+            true
+        }
 }


### PR DESCRIPTION
## 개요
SaveRecipeUseCase 레시피 이미지 저장하는 로직 추가 #73
SaveRecipeUseCase 이미지 저장하는 로직 추가

## 하고자 했던 것
- SaveRecipeUseCase 이미지 저장하는 로직 추가

## 변경 사항
- [x] SaveRecipeUseCase 이미지 저장하는 로직 추가

## 발생한 이슈
### 이미지에 빈 값이 들어올 경우 레시피가 저장되지 않는 문제 발생
RecipeImageRepository에서 빈 문자열을 받으면 Exception이 나면서 발생한 문제
imgPath.isNotEmpty()를 이용하여 빈 문자열이 들어올 경우 빈 값을 저장하도록 처리
처리 중 imgPath를 null로 하는건 어떤지 의견이 나옴
추후 토론 예정