### PR TITLE
[develop] errormap, base list adapter, 로컬 레시피 리스트 정렬 수정

### DIFF
--- a/data/src/main/java/com/kdjj/data/common/ResultExtension.kt
+++ b/data/src/main/java/com/kdjj/data/common/ResultExtension.kt
@@ -4,10 +4,10 @@ import java.lang.Exception
 
 
 inline fun <T> Result<T>.errorMap(
-    transform: (Throwable?) -> Exception
+    transform: (Throwable) -> Exception
 ): Result<T> {
-    return when {
-        isSuccess -> this
-        else -> { Result.failure(transform.invoke(exceptionOrNull()))}
+    return when (val exception = exceptionOrNull()){
+        null -> this
+        else -> { Result.failure(transform.invoke(exception))}
     }
 }

--- a/data/src/main/java/com/kdjj/data/datasource/RecipeListLocalDataSource.kt
+++ b/data/src/main/java/com/kdjj/data/datasource/RecipeListLocalDataSource.kt
@@ -5,7 +5,7 @@ import com.kdjj.domain.model.Recipe
 interface RecipeListLocalDataSource {
     
     suspend fun fetchLatestRecipeListAfter(
-        page: Int
+        index: Int
     ): Result<List<Recipe>>
     
     suspend fun fetchFavoriteRecipeListAfter(
@@ -14,6 +14,10 @@ interface RecipeListLocalDataSource {
     
     suspend fun fetchSearchRecipeListAfter(
         keyword: String,
+        index: Int
+    ): Result<List<Recipe>>
+
+    suspend fun fetchTitleListAfter(
         index: Int
     ): Result<List<Recipe>>
 }

--- a/data/src/main/java/com/kdjj/data/repository/RecipeListRepositoryImpl.kt
+++ b/data/src/main/java/com/kdjj/data/repository/RecipeListRepositoryImpl.kt
@@ -28,9 +28,9 @@ internal class RecipeListRepositoryImpl @Inject constructor(
         recipeListRemoteDataSource.fetchSearchRecipeListAfter(keyword, lastVisibleTitle)
     
     override suspend fun fetchLocalLatestRecipeListAfter(
-        page: Int
+        index: Int
     ): Result<List<Recipe>> =
-        recipeListLocalDataSource.fetchLatestRecipeListAfter(page)
+        recipeListLocalDataSource.fetchLatestRecipeListAfter(index)
     
     override suspend fun fetchLocalFavoriteRecipeListAfter(
         index: Int
@@ -42,4 +42,10 @@ internal class RecipeListRepositoryImpl @Inject constructor(
         index: Int
     ): Result<List<Recipe>> =
         recipeListLocalDataSource.fetchSearchRecipeListAfter(keyword, index)
+
+    override suspend fun fetchLocalTitleRecipeListAfter(
+        index: Int
+    ): Result<List<Recipe>> =
+        recipeListLocalDataSource.fetchTitleListAfter(index)
+
 }

--- a/domain/src/main/java/com/kdjj/domain/model/request/FetchLocalLatestRecipeListRequest.kt
+++ b/domain/src/main/java/com/kdjj/domain/model/request/FetchLocalLatestRecipeListRequest.kt
@@ -1,5 +1,5 @@
 package com.kdjj.domain.model.request
 
 data class FetchLocalLatestRecipeListRequest(
-    val page: Int,
+    val index: Int,
 ) : Request

--- a/domain/src/main/java/com/kdjj/domain/model/request/FetchLocalTitleRecipeListRequest.kt
+++ b/domain/src/main/java/com/kdjj/domain/model/request/FetchLocalTitleRecipeListRequest.kt
@@ -1,0 +1,5 @@
+package com.kdjj.domain.model.request
+
+data class FetchLocalTitleRecipeListRequest(
+    val index: Int
+) : Request

--- a/domain/src/main/java/com/kdjj/domain/repository/RecipeListRepository.kt
+++ b/domain/src/main/java/com/kdjj/domain/repository/RecipeListRepository.kt
@@ -18,7 +18,7 @@ interface RecipeListRepository {
     ): Result<List<Recipe>>
     
     suspend fun fetchLocalLatestRecipeListAfter(
-        page: Int
+        index: Int
     ): Result<List<Recipe>>
     
     suspend fun fetchLocalFavoriteRecipeListAfter(
@@ -27,6 +27,10 @@ interface RecipeListRepository {
     
     suspend fun fetchLocalSearchRecipeListAfter(
         keyword: String,
+        index: Int
+    ): Result<List<Recipe>>
+
+    suspend fun fetchLocalTitleRecipeListAfter(
         index: Int
     ): Result<List<Recipe>>
 }

--- a/domain/src/main/java/com/kdjj/domain/usecase/FetchLocalLatestRecipeListUseCase.kt
+++ b/domain/src/main/java/com/kdjj/domain/usecase/FetchLocalLatestRecipeListUseCase.kt
@@ -10,6 +10,6 @@ internal class FetchLocalLatestRecipeListUseCase @Inject constructor(
 ) : UseCase<FetchLocalLatestRecipeListRequest, @JvmSuppressWildcards List<Recipe>> {
 
     override suspend fun invoke(request: FetchLocalLatestRecipeListRequest): Result<List<Recipe>> =
-        recipeListRepository.fetchLocalLatestRecipeListAfter(request.page)
+        recipeListRepository.fetchLocalLatestRecipeListAfter(request.index)
 
 }

--- a/domain/src/main/java/com/kdjj/domain/usecase/FetchLocalTitleRecipeListUseCase.kt
+++ b/domain/src/main/java/com/kdjj/domain/usecase/FetchLocalTitleRecipeListUseCase.kt
@@ -1,0 +1,13 @@
+package com.kdjj.domain.usecase
+
+import com.kdjj.domain.model.Recipe
+import com.kdjj.domain.model.request.FetchLocalTitleRecipeListRequest
+import com.kdjj.domain.repository.RecipeListRepository
+
+class FetchLocalTitleRecipeListUseCase(
+    private val recipeListRepository: RecipeListRepository,
+) : UseCase<FetchLocalTitleRecipeListRequest, @JvmSuppressWildcards List<Recipe>> {
+
+    override suspend fun invoke(request: FetchLocalTitleRecipeListRequest): Result<List<Recipe>> =
+        recipeListRepository.fetchLocalTitleRecipeListAfter(request.index)
+}

--- a/domain/src/main/java/com/kdjj/domain/usecase/SaveLocalRecipeUseCase.kt
+++ b/domain/src/main/java/com/kdjj/domain/usecase/SaveLocalRecipeUseCase.kt
@@ -42,7 +42,6 @@ internal class SaveLocalRecipeUseCase @Inject constructor(
                     imgPath = recipeImageUri,
                     stepList = recipeStepList
                 )
-            )
-            true
+            ).getOrThrow()
         }
 }

--- a/local/src/main/java/com/kdjj/local/dao/RecipeListDao.kt
+++ b/local/src/main/java/com/kdjj/local/dao/RecipeListDao.kt
@@ -9,8 +9,8 @@ import com.kdjj.local.dto.RecipeDto
 internal interface RecipeListDao {
 
     @Transaction
-    @Query("SELECT * FROM RecipeMeta ORDER BY createTime ASC LIMIT :pageSize OFFSET :page")
-    suspend fun fetchLatestRecipeList(pageSize: Int, page: Int): List<RecipeDto>
+    @Query("SELECT * FROM RecipeMeta ORDER BY createTime ASC LIMIT :pageSize OFFSET :index")
+    suspend fun fetchLatestRecipeList(pageSize: Int, index: Int): List<RecipeDto>
 
     @Transaction
     @Query("SELECT * FROM RecipeMeta WHERE isFavorite = :favorite ORDER BY createTime ASC LIMIT :pageSize OFFSET :index")
@@ -19,4 +19,8 @@ internal interface RecipeListDao {
     @Transaction
     @Query("SELECT * FROM RecipeMeta WHERE title LIKE :keyword LIMIT :pageSize OFFSET :index")
     suspend fun fetchSearchRecipeList(pageSize: Int, keyword: String, index: Int): List<RecipeDto>
+
+    @Transaction
+    @Query("SELECT * FROM RecipeMeta ORDER BY title LIMIT :pageSize OFFSET :index")
+    suspend fun fetchTitleRecipeList(pageSize: Int, index: Int): List<RecipeDto>
 }

--- a/local/src/main/java/com/kdjj/local/dao/RecipeListDao.kt
+++ b/local/src/main/java/com/kdjj/local/dao/RecipeListDao.kt
@@ -9,11 +9,11 @@ import com.kdjj.local.dto.RecipeDto
 internal interface RecipeListDao {
 
     @Transaction
-    @Query("SELECT * FROM RecipeMeta ORDER BY createTime LIMIT :pageSize OFFSET :page")
+    @Query("SELECT * FROM RecipeMeta ORDER BY createTime ASC LIMIT :pageSize OFFSET :page")
     suspend fun fetchLatestRecipeList(pageSize: Int, page: Int): List<RecipeDto>
 
     @Transaction
-    @Query("SELECT * FROM RecipeMeta WHERE isFavorite = :favorite ORDER BY createTime LIMIT :pageSize OFFSET :index")
+    @Query("SELECT * FROM RecipeMeta WHERE isFavorite = :favorite ORDER BY createTime ASC LIMIT :pageSize OFFSET :index")
     suspend fun fetchFavoriteRecipeList(pageSize: Int, index: Int, favorite:Boolean = true): List<RecipeDto>
 
     @Transaction

--- a/local/src/main/java/com/kdjj/local/dataSource/RecipeListLocalDataSourceImpl.kt
+++ b/local/src/main/java/com/kdjj/local/dataSource/RecipeListLocalDataSourceImpl.kt
@@ -17,9 +17,7 @@ internal class RecipeListLocalDataSourceImpl @Inject constructor(
             recipeListDao.fetchLatestRecipeList(PAGE_SIZE, page)
                 .map { it.toDomain() }
         }.errorMap { throwable ->
-            throwable?.let {
-                Exception(it.message)
-            } ?: Exception()
+            Exception(throwable.message)
         }
 
     override suspend fun fetchFavoriteRecipeListAfter(index: Int): Result<List<Recipe>> =
@@ -27,9 +25,7 @@ internal class RecipeListLocalDataSourceImpl @Inject constructor(
             recipeListDao.fetchFavoriteRecipeList(PAGE_SIZE, index)
                 .map { it.toDomain() }
         }.errorMap { throwable ->
-            throwable?.let {
-                Exception(it.message)
-            } ?: Exception()
+            Exception(throwable.message)
         }
 
     override suspend fun fetchSearchRecipeListAfter(
@@ -40,9 +36,7 @@ internal class RecipeListLocalDataSourceImpl @Inject constructor(
             recipeListDao.fetchSearchRecipeList(PAGE_SIZE, "%$keyword%", index)
                 .map { it.toDomain() }
         }.errorMap { throwable ->
-            throwable?.let {
-                Exception(it.message)
-            } ?: Exception()
+            Exception(throwable.message)
         }
 
     companion object {

--- a/local/src/main/java/com/kdjj/local/dataSource/RecipeListLocalDataSourceImpl.kt
+++ b/local/src/main/java/com/kdjj/local/dataSource/RecipeListLocalDataSourceImpl.kt
@@ -12,20 +12,20 @@ internal class RecipeListLocalDataSourceImpl @Inject constructor(
     private val recipeListDao: RecipeListDao,
 ) : RecipeListLocalDataSource {
 
-    override suspend fun fetchLatestRecipeListAfter(page: Int): Result<List<Recipe>> =
+    override suspend fun fetchLatestRecipeListAfter(index: Int): Result<List<Recipe>> =
         runCatching {
-            recipeListDao.fetchLatestRecipeList(PAGE_SIZE, page)
+            recipeListDao.fetchLatestRecipeList(PAGE_SIZE, index)
                 .map { it.toDomain() }
-        }.errorMap { throwable ->
-            Exception(throwable.message)
+        }.errorMap {
+            Exception(it.message)
         }
 
     override suspend fun fetchFavoriteRecipeListAfter(index: Int): Result<List<Recipe>> =
         runCatching {
             recipeListDao.fetchFavoriteRecipeList(PAGE_SIZE, index)
                 .map { it.toDomain() }
-        }.errorMap { throwable ->
-            Exception(throwable.message)
+        }.errorMap {
+            Exception(it.message)
         }
 
     override suspend fun fetchSearchRecipeListAfter(
@@ -35,8 +35,18 @@ internal class RecipeListLocalDataSourceImpl @Inject constructor(
         runCatching {
             recipeListDao.fetchSearchRecipeList(PAGE_SIZE, "%$keyword%", index)
                 .map { it.toDomain() }
-        }.errorMap { throwable ->
-            Exception(throwable.message)
+        }.errorMap {
+            Exception(it.message)
+        }
+
+    override suspend fun fetchTitleListAfter(
+        index: Int
+    ): Result<List<Recipe>> =
+        runCatching {
+            recipeListDao.fetchTitleRecipeList(PAGE_SIZE, index)
+                .map { it.toDomain() }
+        }.errorMap {
+            Exception(it.message)
         }
 
     companion object {

--- a/local/src/main/java/com/kdjj/local/dataSource/RecipeLocalDataSourceImpl.kt
+++ b/local/src/main/java/com/kdjj/local/dataSource/RecipeLocalDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.kdjj.local.dataSource
 
+import com.kdjj.data.common.errorMap
 import com.kdjj.data.datasource.RecipeLocalDataSource
 import com.kdjj.domain.model.Recipe
 import com.kdjj.local.dao.RecipeDao
@@ -16,12 +17,12 @@ internal class RecipeLocalDataSourceImpl @Inject constructor(
         recipe: Recipe
     ): Result<Boolean> =
         withContext(Dispatchers.IO) {
-            try {
+            runCatching {
                 recipeDao.deleteStepList(recipe.recipeId)
                 recipeDao.insertRecipe(recipe)
-                Result.success(true)
-            } catch (e: Exception) {
-                Result.failure(Exception(e.message))
+                true
+            }.errorMap {
+                Exception(it.message)
             }
         }
     
@@ -29,11 +30,11 @@ internal class RecipeLocalDataSourceImpl @Inject constructor(
         recipe: Recipe
     ): Result<Boolean> =
         withContext(Dispatchers.IO) {
-            try {
+            runCatching {
                 recipeDao.updateRecipeMeta(recipe.toDto())
-                Result.success(true)
-            } catch (e: Exception) {
-                Result.failure(Exception(e.message))
+                true
+            }.errorMap {
+                Exception(it.message)
             }
         }
     
@@ -41,11 +42,11 @@ internal class RecipeLocalDataSourceImpl @Inject constructor(
         recipe: Recipe
     ): Result<Boolean> =
         withContext(Dispatchers.IO) {
-            try {
+            runCatching {
                 recipeDao.deleteRecipe(recipe.toDto())
-                Result.success(true)
-            } catch (e: Exception) {
-                Result.failure(Exception(e.message))
+                true
+            }.errorMap {
+                Exception(it.message)
             }
         }
 }

--- a/local/src/main/java/com/kdjj/local/dataSource/RecipeTypeLocalDataSourceImpl.kt
+++ b/local/src/main/java/com/kdjj/local/dataSource/RecipeTypeLocalDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.kdjj.local.dataSource
 
+import com.kdjj.data.common.errorMap
 import com.kdjj.data.datasource.RecipeTypeLocalDataSource
 import com.kdjj.domain.model.RecipeType
 import com.kdjj.local.dao.RecipeTypeDao
@@ -17,26 +18,25 @@ internal class RecipeTypeLocalDataSourceImpl @Inject constructor(
         recipeTypeList: List<RecipeType>
     ): Result<Boolean> =
         withContext(Dispatchers.IO) {
-            try {
+            runCatching {
                 recipeTypeList.map { recipeType ->
                     recipeType.toDto()
                 }.forEach { recipeTypeEntity ->
                     recipeTypeDao.insertRecipeType(recipeTypeEntity)
                 }
-                Result.success(true)
-            } catch (e: Exception) {
-                Result.failure(Exception(e.message))
+                true
+            }.errorMap {
+                Exception(it.message)
             }
         }
     
     override suspend fun fetchRecipeTypeList(): Result<List<RecipeType>> =
         withContext(Dispatchers.IO) {
-            try {
-                val recipeTypeList = recipeTypeDao.getAllRecipeTypeList()
+            runCatching {
+                recipeTypeDao.getAllRecipeTypeList()
                     .map { it.toDomain() }
-                Result.success(recipeTypeList)
-            } catch (e: Exception) {
-                Result.failure(Exception(e.message))
+            }.errorMap {
+                Exception(it.message)
             }
         }
 }

--- a/presentation/src/main/java/com/kdjj/presentation/view/adapter/BaseListAdapter.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/adapter/BaseListAdapter.kt
@@ -11,33 +11,27 @@ abstract class BaseListAdapter<T, VDB : ViewDataBinding> constructor(
 ) : ListAdapter<T, BaseViewHolder<T, VDB>>(diffUtil) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BaseViewHolder<T, VDB> {
-        val binding = createBinding(parent, viewType)
-        return BaseViewHolder(binding, { b, getItemPosition, itemViewType -> initViewHolder(b, getItemPosition, itemViewType)} )
+        val binding = createBinding(parent)
+        return BaseViewHolder(binding, { b, getItemPosition -> initViewHolder(b, getItemPosition)} )
     }
 
-    protected abstract fun createBinding(parent: ViewGroup, viewType: Int): VDB
+    protected abstract fun createBinding(parent: ViewGroup): VDB
 
-    protected open fun initViewHolder(binding: VDB, getItemPosition: () -> Int, viewType: Int) {}
+    protected open fun initViewHolder(binding: VDB, getItemPosition: () -> Int) {}
 
     override fun onBindViewHolder(holder: BaseViewHolder<T, VDB>, position: Int) {
-        bind(holder, getItem(position), holder.itemViewType)
+        bind(holder, getItem(position))
     }
 
-    protected abstract fun bind(holder: BaseViewHolder<T, VDB>, item: T, viewType: Int)
+    protected abstract fun bind(holder: BaseViewHolder<T, VDB>, item: T)
 }
 
-open class BaseViewHolder<T, VDB : ViewDataBinding> constructor(
+class BaseViewHolder<T, VDB : ViewDataBinding> constructor(
     val binding: VDB,
-    onViewHolderInit: (VDB, getAdapterPosition: () -> Int, viewType: Int) -> Unit,
+    onViewHolderInit: (VDB, getAdapterPosition: () -> Int) -> Unit,
 ) : RecyclerView.ViewHolder(binding.root) {
 
     init {
-        onViewHolderInit.invoke(binding, { bindingAdapterPosition }, itemViewType)
-    }
-
-    open fun bind(item: T) {
-    }
-
-    open fun onViewRecycled() {
+        onViewHolderInit.invoke(binding, { bindingAdapterPosition })
     }
 }

--- a/presentation/src/main/java/com/kdjj/presentation/view/adapter/OthersRecipeListAdapter.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/adapter/OthersRecipeListAdapter.kt
@@ -9,7 +9,7 @@ import com.kdjj.presentation.common.calculateUpdateTime
 import com.kdjj.presentation.databinding.ItemOthersRecipeBinding
 
 class OthersRecipeListAdapter(
-) : BaseListAdapter<Recipe, ItemOthersRecipeBinding>(RecipeDiffCallback()) {
+) : SingleViewTypeListAdapter<Recipe, ItemOthersRecipeBinding>(RecipeDiffCallback()) {
 
     override fun createBinding(parent: ViewGroup): ItemOthersRecipeBinding =
         ItemOthersRecipeBinding.inflate(LayoutInflater.from(parent.context), parent, false)
@@ -24,7 +24,7 @@ class OthersRecipeListAdapter(
     }
 
     override fun bind(
-        holder: BaseViewHolder<Recipe, ItemOthersRecipeBinding>,
+        holder: SingleViewTypeViewHolder<Recipe, ItemOthersRecipeBinding>,
         item: Recipe,
     ) {
        with(holder.binding) {

--- a/presentation/src/main/java/com/kdjj/presentation/view/adapter/OthersRecipeListAdapter.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/adapter/OthersRecipeListAdapter.kt
@@ -11,13 +11,12 @@ import com.kdjj.presentation.databinding.ItemOthersRecipeBinding
 class OthersRecipeListAdapter(
 ) : BaseListAdapter<Recipe, ItemOthersRecipeBinding>(RecipeDiffCallback()) {
 
-    override fun createBinding(parent: ViewGroup, viewType: Int): ItemOthersRecipeBinding =
+    override fun createBinding(parent: ViewGroup): ItemOthersRecipeBinding =
         ItemOthersRecipeBinding.inflate(LayoutInflater.from(parent.context), parent, false)
 
     override fun initViewHolder(
         binding: ItemOthersRecipeBinding,
         getItemPosition: () -> Int,
-        viewType: Int
     ) {
         binding.root.setOnClickListener {
             //todo: clicklisntener
@@ -27,7 +26,6 @@ class OthersRecipeListAdapter(
     override fun bind(
         holder: BaseViewHolder<Recipe, ItemOthersRecipeBinding>,
         item: Recipe,
-        viewType: Int
     ) {
        with(holder.binding) {
            textViewOthersItemTitle.text = item.title

--- a/presentation/src/main/java/com/kdjj/presentation/view/adapter/SingleViewTypeListAdapter.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/adapter/SingleViewTypeListAdapter.kt
@@ -6,27 +6,27 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 
-abstract class BaseListAdapter<T, VDB : ViewDataBinding> constructor(
+abstract class SingleViewTypeListAdapter<T, VDB : ViewDataBinding> constructor(
     diffUtil : DiffUtil.ItemCallback<T>,
-) : ListAdapter<T, BaseViewHolder<T, VDB>>(diffUtil) {
+) : ListAdapter<T, SingleViewTypeViewHolder<T, VDB>>(diffUtil) {
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BaseViewHolder<T, VDB> {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SingleViewTypeViewHolder<T, VDB> {
         val binding = createBinding(parent)
-        return BaseViewHolder(binding, { b, getItemPosition -> initViewHolder(b, getItemPosition)} )
+        return SingleViewTypeViewHolder(binding, { b, getItemPosition -> initViewHolder(b, getItemPosition)} )
     }
 
     protected abstract fun createBinding(parent: ViewGroup): VDB
 
     protected open fun initViewHolder(binding: VDB, getItemPosition: () -> Int) {}
 
-    override fun onBindViewHolder(holder: BaseViewHolder<T, VDB>, position: Int) {
+    override fun onBindViewHolder(holder: SingleViewTypeViewHolder<T, VDB>, position: Int) {
         bind(holder, getItem(position))
     }
 
-    protected abstract fun bind(holder: BaseViewHolder<T, VDB>, item: T)
+    protected abstract fun bind(holder: SingleViewTypeViewHolder<T, VDB>, item: T)
 }
 
-class BaseViewHolder<T, VDB : ViewDataBinding> constructor(
+class SingleViewTypeViewHolder<T, VDB : ViewDataBinding> constructor(
     val binding: VDB,
     onViewHolderInit: (VDB, getAdapterPosition: () -> Int) -> Unit,
 ) : RecyclerView.ViewHolder(binding.root) {

--- a/remote/src/main/java/com/kdjj/remote/dao/FirebaseStorageServiceImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/dao/FirebaseStorageServiceImpl.kt
@@ -20,7 +20,8 @@ internal class FirebaseStorageServiceImpl @Inject constructor(
             runCatching {
                 storageRef.storage
                     .getReferenceFromUrl(uri)
-                    .getBytes(MAX_SIZE).await()
+                    .getBytes(MAX_SIZE)
+                    .await()
             }.errorMap {
                 Exception(it.message)
             }

--- a/remote/src/main/java/com/kdjj/remote/dao/FirebaseStorageServiceImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/dao/FirebaseStorageServiceImpl.kt
@@ -2,6 +2,7 @@ package com.kdjj.remote.dao
 
 import android.net.Uri
 import com.google.firebase.storage.StorageReference
+import com.kdjj.data.common.errorMap
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
@@ -16,13 +17,12 @@ internal class FirebaseStorageServiceImpl @Inject constructor(
         uri: String
     ): Result<ByteArray> {
         return withContext(Dispatchers.IO) {
-            try {
-                val byteArray = storageRef.storage
+            runCatching {
+                storageRef.storage
                     .getReferenceFromUrl(uri)
                     .getBytes(MAX_SIZE).await()
-                Result.success(byteArray)
-            } catch (e: Exception) {
-                Result.failure(e)
+            }.errorMap {
+                Exception(it.message)
             }
         }
     }
@@ -31,14 +31,14 @@ internal class FirebaseStorageServiceImpl @Inject constructor(
         uri: String
     ): Result<String> {
         return withContext(Dispatchers.IO) {
-            try {
+            runCatching {
                 val file = Uri.fromFile(File(uri))
                 val refer = storageRef.child("images/${file.lastPathSegment}")
                 refer.putFile(file).await()
                 val newUri = refer.downloadUrl.await()
-                Result.success(newUri.toString())
-            } catch (e: Exception) {
-                Result.failure(e)
+                newUri.toString()
+            }.errorMap {
+                Exception(it.message)
             }
         }
     }

--- a/remote/src/main/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.kdjj.remote.datasource
 
+import com.kdjj.data.common.errorMap
 import com.kdjj.data.datasource.RecipeListRemoteDataSource
 import com.kdjj.domain.model.Recipe
 import com.kdjj.remote.dao.RemoteRecipeListService
@@ -12,31 +13,28 @@ internal class RecipeListRemoteDataSourceImpl @Inject constructor(
     override suspend fun fetchLatestRecipeListAfter(
         lastVisibleCreateTime: Long
     ): Result<List<Recipe>> =
-        try {
-            val recipeList = recipeListService.fetchLatestRecipeListAfter(lastVisibleCreateTime)
-            Result.success(recipeList)
-        } catch (e: Exception) {
-            Result.failure(e)
+        runCatching {
+            recipeListService.fetchLatestRecipeListAfter(lastVisibleCreateTime)
+        }.errorMap {
+            Exception(it.message)
         }
     
     override suspend fun fetchPopularRecipeListAfter(
         lastVisibleViewCount: Int
     ): Result<List<Recipe>> =
-        try {
-            val recipeList = recipeListService.fetchPopularRecipeListAfter(lastVisibleViewCount)
-            Result.success(recipeList)
-        } catch (e: Exception) {
-            Result.failure(e)
+        runCatching {
+            recipeListService.fetchPopularRecipeListAfter(lastVisibleViewCount)
+        }.errorMap {
+            Exception(it.message)
         }
     
     override suspend fun fetchSearchRecipeListAfter(
         keyword: String,
         lastVisibleTitle: String
     ): Result<List<Recipe>> =
-        try {
-            val recipeList = recipeListService.fetchSearchRecipeListAfter(keyword, lastVisibleTitle)
-            Result.success(recipeList)
-        } catch (e: Exception) {
-            Result.failure(e)
+        runCatching {
+            recipeListService.fetchSearchRecipeListAfter(keyword, lastVisibleTitle)
+        }.errorMap {
+            Exception(it.message)
         }
 }

--- a/remote/src/main/java/com/kdjj/remote/datasource/RecipeRemoteDataSourceImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/datasource/RecipeRemoteDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.kdjj.remote.datasource
 
+import com.kdjj.data.common.errorMap
 import com.kdjj.data.datasource.RecipeRemoteDataSource
 import com.kdjj.domain.model.Recipe
 import com.kdjj.remote.dao.RemoteRecipeService
@@ -10,26 +11,23 @@ internal class RecipeRemoteDataSourceImpl @Inject constructor(
 ) : RecipeRemoteDataSource {
     
     override suspend fun uploadRecipe(recipe: Recipe): Result<Unit> =
-        try {
+        runCatching {
             recipeService.uploadRecipe(recipe)
-            Result.success(Unit)
-        } catch (e: Exception) {
-            Result.failure(e)
+        }.errorMap {
+            Exception(it.message)
         }
     
     override suspend fun increaseViewCount(recipe: Recipe): Result<Unit> =
-        try {
+        runCatching {
             recipeService.increaseViewCount(recipe)
-            Result.success(Unit)
-        } catch (e: Exception) {
-            Result.failure(e)
+        }.errorMap {
+            Exception(it.message)
         }
     
     override suspend fun deleteRecipe(recipe: Recipe): Result<Unit> =
-        try {
+        runCatching {
             recipeService.deleteRecipe(recipe)
-            Result.success(Unit)
-        }catch(e: Exception){
-            Result.failure(e)
+        }.errorMap {
+            Exception(it.message)
         }
 }

--- a/remote/src/main/java/com/kdjj/remote/datasource/RecipeTypeRemoteDataSourceImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/datasource/RecipeTypeRemoteDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.kdjj.remote.datasource
 
+import com.kdjj.data.common.errorMap
 import com.kdjj.data.datasource.RecipeTypeRemoteDataSource
 import com.kdjj.domain.model.RecipeType
 import com.kdjj.remote.dao.FirestoreService
@@ -10,11 +11,11 @@ internal class RecipeTypeRemoteDataSourceImpl @Inject constructor(
 ) : RecipeTypeRemoteDataSource {
     
     override suspend fun fetchRecipeTypeList(): Result<List<RecipeType>> =
-        try {
+        runCatching {
             val recipeTypeList = fireStoreService.fetchRecipeTypes()
             if (recipeTypeList.isEmpty()) throw Exception("Can't fetch recipe type.")
-            Result.success(recipeTypeList)
-        } catch (e: Exception) {
-            Result.failure(e)
+            recipeTypeList
+        }.errorMap {
+            Exception(it.message)
         }
 }


### PR DESCRIPTION
## 개요
Issue: https://github.com/boostcampwm-2021/Android08-Ratatouille/issues/80
## 하고자 했던 것
- erroMap 에서 throwable 을 nonNullable 하게 수정
- BaseListAdapter 에서 viewType 넘겨주는 것 제거
BaseListAdapter는 viewType 하나 일때 사용가능하므로, viewType을 하나하나 넘겨줄 필요가 없다
- 최신순 정렬 할때 최신순이 아닌 문제 -> orderby ascending
## 변경 사항
- erroMap 수정 c4ff0dac45411245ed9175dae173390e472141a6
- BaseListAdapter 수정 bfa126736d05160d2dbb5c7d46928b96c38aec3e
- 로컬 레시피 리스트 가져올 때 orderby ascending beaaf069daff59ae2d9df07908762e891c00074f
## 발생한 이슈
