### PR TITLE
[develop] RecipeImage, UseCase, Repository, LocalDataSource, FileSaveHelper 수정

### DIFF
--- a/data/src/main/java/com/kdjj/data/datasource/RecipeImageLocalDataSource.kt
+++ b/data/src/main/java/com/kdjj/data/datasource/RecipeImageLocalDataSource.kt
@@ -10,4 +10,6 @@ interface RecipeImageLocalDataSource {
         byteArray: ByteArray,
         fileName: String
     ): Result<String>
+
+    suspend fun copyExif(oldPath: String, newPath: String): Result<Unit>
 }

--- a/data/src/main/java/com/kdjj/data/datasource/RecipeImageLocalDataSource.kt
+++ b/data/src/main/java/com/kdjj/data/datasource/RecipeImageLocalDataSource.kt
@@ -11,6 +11,4 @@ interface RecipeImageLocalDataSource {
         fileName: String,
         degree: Float? = null
     ): Result<String>
-
-    suspend fun copyExif(oldPath: String, newPath: String): Result<Unit>
 }

--- a/data/src/main/java/com/kdjj/data/datasource/RecipeImageLocalDataSource.kt
+++ b/data/src/main/java/com/kdjj/data/datasource/RecipeImageLocalDataSource.kt
@@ -4,11 +4,12 @@ interface RecipeImageLocalDataSource {
     
     suspend fun convertToByteArray(
         uri: String
-    ): Result<ByteArray>
+    ): Result<Pair<ByteArray, Float?>>
     
     suspend fun convertToInternalStorageUri(
         byteArray: ByteArray,
-        fileName: String
+        fileName: String,
+        degree: Float? = null
     ): Result<String>
 
     suspend fun copyExif(oldPath: String, newPath: String): Result<Unit>

--- a/data/src/main/java/com/kdjj/data/repository/RecipeImageRepositoryImpl.kt
+++ b/data/src/main/java/com/kdjj/data/repository/RecipeImageRepositoryImpl.kt
@@ -35,8 +35,6 @@ internal class RecipeImageRepositoryImpl @Inject constructor(
             .getOrThrow()
         val newUri = recipeImageLocalDataSource.convertToInternalStorageUri(byteArray, fileName)
             .getOrThrow()
-        recipeImageLocalDataSource.copyExif(uri, newUri)
-            .getOrThrow()
         newUri
     }
 }

--- a/data/src/main/java/com/kdjj/data/repository/RecipeImageRepositoryImpl.kt
+++ b/data/src/main/java/com/kdjj/data/repository/RecipeImageRepositoryImpl.kt
@@ -9,29 +9,34 @@ internal class RecipeImageRepositoryImpl @Inject constructor(
     private val recipeImageLocalDataSource: RecipeImageLocalDataSource,
     private val recipeImageRemoteDataSource: RecipeImageRemoteDataSource
 ) : RecipeImageRepository {
-    
-    override suspend fun convertRemoteUriToByteArray(
-        uri: String
-    ): Result<ByteArray> {
-        return recipeImageRemoteDataSource.fetchRecipeImage(uri)
-    }
-    
-    override suspend fun convertLocalUriToByteArray(
-        uri: String
-    ): Result<ByteArray> {
-        return recipeImageLocalDataSource.convertToByteArray(uri)
-    }
-    
-    override suspend fun convertLocalUriToRemoteStorageUri(
+
+    override suspend fun convertInternalUriToRemoteStorageUri(
         uri: String
     ): Result<String> {
         return recipeImageRemoteDataSource.uploadRecipeImage(uri)
     }
-    
-    override suspend fun convertByteArrayToLocalStorageUri(
-        byteArray: ByteArray,
+
+    override suspend fun copyExternalImageToInternal(
+        uri: String,
         fileName: String
-    ): Result<String> {
-        return recipeImageLocalDataSource.convertToInternalStorageUri(byteArray, fileName)
+    ): Result<String> = runCatching {
+        val (byteArray, degree) = recipeImageLocalDataSource.convertToByteArray(uri)
+            .getOrThrow()
+        val newUri = recipeImageLocalDataSource.convertToInternalStorageUri(byteArray, fileName, degree)
+            .getOrThrow()
+        newUri
+    }
+
+    override suspend fun copyRemoteImageToInternal(
+        uri: String,
+        fileName: String
+    ): Result<String> = runCatching {
+        val byteArray = recipeImageRemoteDataSource.fetchRecipeImage(uri)
+            .getOrThrow()
+        val newUri = recipeImageLocalDataSource.convertToInternalStorageUri(byteArray, fileName)
+            .getOrThrow()
+        recipeImageLocalDataSource.copyExif(uri, newUri)
+            .getOrThrow()
+        newUri
     }
 }

--- a/data/src/test/java/com/kdjj/data/recipeimage/RecipeImageRepositoryImplTest.kt
+++ b/data/src/test/java/com/kdjj/data/recipeimage/RecipeImageRepositoryImplTest.kt
@@ -63,8 +63,6 @@ class RecipeImageRepositoryImplTest {
                 testFileName
             )
         ).thenReturn(Result.success(testUri))
-        `when`(mockRecipeImageLocalDataSource.copyExif(testUri, testUri))
-            .thenReturn(Result.success(Unit))
 
         //when
         val result = recipeImageRepositoryImpl.copyRemoteImageToInternal(testUri, testFileName)

--- a/data/src/test/java/com/kdjj/data/recipeimage/RecipeImageRepositoryImplTest.kt
+++ b/data/src/test/java/com/kdjj/data/recipeimage/RecipeImageRepositoryImplTest.kt
@@ -11,78 +11,78 @@ import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 
 class RecipeImageRepositoryImplTest {
-	
-	private lateinit var mockRecipeImageLocalDataSource: RecipeImageLocalDataSource
-	private lateinit var mockRecipeImageRemoteDataSource: RecipeImageRemoteDataSource
-	private lateinit var recipeImageRepositoryImpl: RecipeImageRepositoryImpl
-	private val testUri = "this is test uri"
-	private val testByteArray = testUri.toByteArray()
-	
-	@Before
-	fun setup() {
-		mockRecipeImageLocalDataSource = mock(RecipeImageLocalDataSource::class.java)
-		mockRecipeImageRemoteDataSource = mock(RecipeImageRemoteDataSource::class.java)
-		recipeImageRepositoryImpl = RecipeImageRepositoryImpl(
-			mockRecipeImageLocalDataSource,
-			mockRecipeImageRemoteDataSource
-		)
-	}
-	
-	@Test
-	fun convertToByteArrayRemote_getRemoteImageByteArray_true(): Unit = runBlocking {
-		//given
-		`when`(mockRecipeImageRemoteDataSource.fetchRecipeImage(testUri)).thenReturn(
-			Result.success(
-				testByteArray
-			)
-		)
-		//when
-		val byteArrayResult = recipeImageRepositoryImpl.convertRemoteUriToByteArray(testUri)
-		//then
-		assertEquals(testByteArray, byteArrayResult.getOrNull())
-	}
-	
-	@Test
-	fun convertToByteArrayLocal_getLocalImageByteArray_true(): Unit = runBlocking {
-		//given
-		`when`(mockRecipeImageLocalDataSource.convertToByteArray(testUri)).thenReturn(
-			Result.success(
-				testByteArray
-			)
-		)
-		//when
-		val byteArrayResult = recipeImageRepositoryImpl.convertLocalUriToByteArray(testUri)
-		//then
-		assertEquals(testByteArray, byteArrayResult.getOrNull())
-	}
-	
-	@Test
-	fun convertToRemoteStorageUri_getRemoteImageUri_true(): Unit = runBlocking {
-		//given
-		`when`(mockRecipeImageRemoteDataSource.uploadRecipeImage(testUri)).thenReturn(
-			Result.success(
-				testUri
-			)
-		)
-		//when
-		val newImagePathResult = recipeImageRepositoryImpl.convertLocalUriToRemoteStorageUri(testUri)
-		//then
-		assertEquals(testUri, newImagePathResult.getOrNull())
-	}
-	
-	@Test
-	fun convertToLocalStorageUri_getLocalImageUri_true(): Unit = runBlocking {
-		//given
-		`when`(
-			mockRecipeImageLocalDataSource.convertToInternalStorageUri(
-				testByteArray,
-				"fileName"
-			)
-		).thenReturn(Result.success(testUri))
-		//when
-		val newImagePathResult =
-			recipeImageRepositoryImpl.convertByteArrayToLocalStorageUri(testByteArray, "fileName")
-		//then
-		assertEquals(testUri, newImagePathResult.getOrNull())
-	}
+
+    private lateinit var mockRecipeImageLocalDataSource: RecipeImageLocalDataSource
+    private lateinit var mockRecipeImageRemoteDataSource: RecipeImageRemoteDataSource
+    private lateinit var recipeImageRepositoryImpl: RecipeImageRepositoryImpl
+    private val testUri = "this is test uri"
+    private val testByteArray = testUri.toByteArray()
+    private val testDegree = 90f
+    private val testFileName = "fileName"
+
+    @Before
+    fun setup() {
+        mockRecipeImageLocalDataSource = mock(RecipeImageLocalDataSource::class.java)
+        mockRecipeImageRemoteDataSource = mock(RecipeImageRemoteDataSource::class.java)
+        recipeImageRepositoryImpl = RecipeImageRepositoryImpl(
+            mockRecipeImageLocalDataSource,
+            mockRecipeImageRemoteDataSource
+        )
+    }
+
+    @Test
+    fun copyExternalImageToInternal(): Unit = runBlocking {
+        //given
+        `when`(mockRecipeImageLocalDataSource.convertToByteArray(testUri)).thenReturn(
+            Result.success(testByteArray to testDegree)
+        )
+        `when`(
+            mockRecipeImageLocalDataSource.convertToInternalStorageUri(
+                testByteArray,
+                testFileName,
+                testDegree
+            )
+        ).thenReturn(Result.success(testUri))
+
+        //when
+        val result = recipeImageRepositoryImpl.copyExternalImageToInternal(testUri, testFileName)
+
+        //then
+        assertEquals(testUri, result.getOrNull())
+    }
+
+    @Test
+    fun copyRemoteImageToInternal(): Unit = runBlocking {
+        //givne
+        `when`(mockRecipeImageRemoteDataSource.fetchRecipeImage(testUri)).thenReturn(
+            Result.success(testByteArray)
+        )
+        `when`(
+            mockRecipeImageLocalDataSource.convertToInternalStorageUri(
+                testByteArray,
+                testFileName
+            )
+        ).thenReturn(Result.success(testUri))
+        `when`(mockRecipeImageLocalDataSource.copyExif(testUri, testUri))
+            .thenReturn(Result.success(Unit))
+
+        //when
+        val result = recipeImageRepositoryImpl.copyRemoteImageToInternal(testUri, testFileName)
+
+        //then
+        assertEquals(testUri, result.getOrNull())
+    }
+
+    @Test
+    fun convertToRemoteStorageUri_getRemoteImageUri_true(): Unit = runBlocking {
+        //given
+        `when`(mockRecipeImageRemoteDataSource.uploadRecipeImage(testUri)).thenReturn(
+            Result.success(testUri)
+        )
+        //when
+        val newImagePathResult =
+            recipeImageRepositoryImpl.convertInternalUriToRemoteStorageUri(testUri)
+        //then
+        assertEquals(testUri, newImagePathResult.getOrNull())
+    }
 }

--- a/domain/src/main/java/com/kdjj/domain/repository/RecipeImageRepository.kt
+++ b/domain/src/main/java/com/kdjj/domain/repository/RecipeImageRepository.kt
@@ -1,21 +1,18 @@
 package com.kdjj.domain.repository
 
 interface RecipeImageRepository {
-    
-    suspend fun convertRemoteUriToByteArray(
-        uri: String
-    ): Result<ByteArray>
-    
-    suspend fun convertLocalUriToByteArray(
-        uri: String
-    ): Result<ByteArray>
-    
-    suspend fun convertLocalUriToRemoteStorageUri(
+
+    suspend fun convertInternalUriToRemoteStorageUri(
         uri: String
     ): Result<String>
-    
-    suspend fun convertByteArrayToLocalStorageUri(
-        byteArray: ByteArray,
+
+    suspend fun copyExternalImageToInternal(
+        uri: String,
+        fileName: String
+    ): Result<String>
+
+    suspend fun copyRemoteImageToInternal(
+        uri: String,
         fileName: String
     ): Result<String>
 }

--- a/domain/src/main/java/com/kdjj/domain/usecase/SaveLocalRecipeUseCase.kt
+++ b/domain/src/main/java/com/kdjj/domain/usecase/SaveLocalRecipeUseCase.kt
@@ -15,22 +15,16 @@ internal class SaveLocalRecipeUseCase @Inject constructor(
             val recipe = request.recipe
             val recipeImageUri = when (recipe.imgPath.isNotEmpty()) {
                 true -> {
-                    val recipeImageByteArray =
-                        imageRepository.convertLocalUriToByteArray(recipe.imgPath).getOrThrow()
-                    imageRepository.convertByteArrayToLocalStorageUri(
-                        recipeImageByteArray, recipe.recipeId
-                    ).getOrThrow()
+                    imageRepository.copyExternalImageToInternal(recipe.imgPath, recipe.recipeId)
+                        .getOrThrow()
                 }
                 false -> ""
             }
             val recipeStepList = recipe.stepList.map { step ->
                 val stepImageUri = when (step.imgPath.isNotEmpty()) {
                     true -> {
-                        val stepImageByteArray =
-                            imageRepository.convertLocalUriToByteArray(step.imgPath).getOrThrow()
-                        imageRepository.convertByteArrayToLocalStorageUri(
-                            stepImageByteArray, step.stepId
-                        ).getOrThrow()
+                        imageRepository.copyExternalImageToInternal(step.imgPath, step.stepId)
+                            .getOrThrow()
                     }
                     false -> ""
                 }

--- a/local/src/main/java/com/kdjj/local/FileSaveHelper.kt
+++ b/local/src/main/java/com/kdjj/local/FileSaveHelper.kt
@@ -3,7 +3,10 @@ package com.kdjj.local
 import android.content.ContentResolver
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.graphics.Matrix
+import android.media.ExifInterface
 import android.net.Uri
+import android.os.Build
 import android.os.FileUtils
 import android.util.Log
 import com.kdjj.data.common.errorMap
@@ -21,10 +24,24 @@ class FileSaveHelper @Inject constructor(
     private val contentResolver: ContentResolver
 ) {
 
-    suspend fun convertToByteArray(uri: String): Result<ByteArray> = withContext(Dispatchers.IO) {
+    suspend fun convertToByteArray(uri: String): Result<Pair<ByteArray, Float?>> = withContext(Dispatchers.IO) {
         runCatching {
             val inputStream = contentResolver.openInputStream(Uri.parse(uri))
-            inputStream?.readBytes() ?: throw Exception()
+            val byteArray = inputStream?.readBytes() ?: throw Exception()
+
+            val exifInputStream = contentResolver.openInputStream(Uri.parse(uri))
+            val oldExif = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                ExifInterface(exifInputStream ?: throw Exception())
+            } else {
+                ExifInterface(uri)
+            }
+            val degree = when (oldExif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)) {
+                ExifInterface.ORIENTATION_ROTATE_90 -> 90f
+                ExifInterface.ORIENTATION_ROTATE_180 -> 180f
+                ExifInterface.ORIENTATION_ROTATE_270 -> 270f
+                else -> null
+            }
+            byteArray to degree
         }.errorMap {
             Exception(it.message)
         }
@@ -32,13 +49,14 @@ class FileSaveHelper @Inject constructor(
 
     suspend fun convertToInternalStorageUri(
         byteArray: ByteArray,
-        fileName: String
+        fileName: String,
+        degree: Float?
     ): Result<String> = withContext(Dispatchers.IO) {
         var fos: FileOutputStream? = null
         runCatching {
             val filePath = "$fileDir/${fileName}.png"
             fos = FileOutputStream(filePath)
-            val bitmap = convertByteArrayToBitmap(byteArray)
+            val bitmap = convertByteArrayToBitmap(byteArray, degree)
             bitmap.compress(Bitmap.CompressFormat.PNG, 100, fos)
             filePath
         }.errorMap {
@@ -46,7 +64,7 @@ class FileSaveHelper @Inject constructor(
         }
     }
 
-    private fun convertByteArrayToBitmap(byteArray: ByteArray): Bitmap {
+    private fun convertByteArrayToBitmap(byteArray: ByteArray, degree: Float?): Bitmap {
         val bitmap = BitmapFactory.decodeByteArray(byteArray, 0, byteArray.size)
         val width = bitmap.width.toFloat()
         val height = bitmap.height.toFloat()
@@ -59,8 +77,37 @@ class FileSaveHelper @Inject constructor(
         } else {
             width to height
         }
-        return Bitmap.createScaledBitmap(bitmap, scaledWidth.toInt(), scaledHeight.toInt(), true)
+        return Bitmap.createScaledBitmap(bitmap, scaledWidth.toInt(), scaledHeight.toInt(), true).let { scaledBitmap ->
+            degree?.let {
+                val matrix = Matrix().apply {
+                    postRotate(degree)
+                }
+                Bitmap.createBitmap(scaledBitmap, 0, 0, scaledBitmap.width, scaledBitmap.height, matrix, true)
+            } ?: scaledBitmap
+        }
     }
+
+    suspend fun copyExif(
+        oldPath: String,
+        newPath: String
+    ): Result<Unit> =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val inputStream = contentResolver.openInputStream(Uri.parse(oldPath))
+                val oldExif = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                    ExifInterface(inputStream ?: throw Exception())
+                } else {
+                    ExifInterface(oldPath)
+                }
+                val exifOrientation = oldExif.getAttribute(ExifInterface.TAG_ORIENTATION)
+                exifOrientation?.let {
+                    val newExif = ExifInterface(newPath)
+                    newExif.setAttribute(ExifInterface.TAG_ORIENTATION, exifOrientation)
+                    newExif.saveAttributes()
+                }
+                return@runCatching
+            }
+        }
 
     companion object{
         const val MAX_WIDTH_HEIGHT_SIZE = 300

--- a/local/src/main/java/com/kdjj/local/FileSaveHelper.kt
+++ b/local/src/main/java/com/kdjj/local/FileSaveHelper.kt
@@ -87,28 +87,6 @@ class FileSaveHelper @Inject constructor(
         }
     }
 
-    suspend fun copyExif(
-        oldPath: String,
-        newPath: String
-    ): Result<Unit> =
-        withContext(Dispatchers.IO) {
-            runCatching {
-                val inputStream = contentResolver.openInputStream(Uri.parse(oldPath))
-                val oldExif = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                    ExifInterface(inputStream ?: throw Exception())
-                } else {
-                    ExifInterface(oldPath)
-                }
-                val exifOrientation = oldExif.getAttribute(ExifInterface.TAG_ORIENTATION)
-                exifOrientation?.let {
-                    val newExif = ExifInterface(newPath)
-                    newExif.setAttribute(ExifInterface.TAG_ORIENTATION, exifOrientation)
-                    newExif.saveAttributes()
-                }
-                return@runCatching
-            }
-        }
-
     companion object{
         const val MAX_WIDTH_HEIGHT_SIZE = 300
     }

--- a/local/src/main/java/com/kdjj/local/dataSource/RecipeImageLocalDataSourceImpl.kt
+++ b/local/src/main/java/com/kdjj/local/dataSource/RecipeImageLocalDataSourceImpl.kt
@@ -21,12 +21,5 @@ internal class RecipeImageLocalDataSourceImpl @Inject constructor(
     ): Result<String> {
         return fileSaveHelper.convertToInternalStorageUri(byteArray, fileName, degree)
     }
-
-    override suspend fun copyExif(
-        oldPath: String,
-        newPath: String
-    ): Result<Unit> {
-        return fileSaveHelper.copyExif(oldPath, newPath)
-    }
 }
 

--- a/local/src/main/java/com/kdjj/local/dataSource/RecipeImageLocalDataSourceImpl.kt
+++ b/local/src/main/java/com/kdjj/local/dataSource/RecipeImageLocalDataSourceImpl.kt
@@ -1,12 +1,7 @@
 package com.kdjj.local.dataSource
 
-import android.media.ExifInterface
-import com.kdjj.data.common.errorMap
 import com.kdjj.data.datasource.RecipeImageLocalDataSource
 import com.kdjj.local.FileSaveHelper
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import java.io.IOException
 import javax.inject.Inject
 
 internal class RecipeImageLocalDataSourceImpl @Inject constructor(
@@ -15,34 +10,23 @@ internal class RecipeImageLocalDataSourceImpl @Inject constructor(
 
     override suspend fun convertToByteArray(
         uri: String
-    ): Result<ByteArray> {
+    ): Result<Pair<ByteArray, Float?>> {
         return fileSaveHelper.convertToByteArray(uri)
     }
 
     override suspend fun convertToInternalStorageUri(
         byteArray: ByteArray,
-        fileName: String
+        fileName: String,
+        degree: Float?
     ): Result<String> {
-        return fileSaveHelper.convertToInternalStorageUri(byteArray, fileName)
+        return fileSaveHelper.convertToInternalStorageUri(byteArray, fileName, degree)
     }
 
     override suspend fun copyExif(
         oldPath: String,
         newPath: String
-    ): Result<Unit> =
-        withContext(Dispatchers.IO) {
-            kotlin.runCatching {
-                val oldExif = ExifInterface(oldPath)
-                val exifOrientation = oldExif.getAttribute(ExifInterface.TAG_ORIENTATION)
-                exifOrientation?.let {
-                    val newExif = ExifInterface(newPath)
-                    newExif.setAttribute(ExifInterface.TAG_ORIENTATION, exifOrientation)
-                    newExif.saveAttributes()
-                }
-                return@runCatching
-            }.errorMap {
-                Exception(it.message)
-            }
-        }
+    ): Result<Unit> {
+        return fileSaveHelper.copyExif(oldPath, newPath)
+    }
 }
 

--- a/local/src/main/java/com/kdjj/local/dataSource/RecipeImageLocalDataSourceImpl.kt
+++ b/local/src/main/java/com/kdjj/local/dataSource/RecipeImageLocalDataSourceImpl.kt
@@ -1,23 +1,48 @@
 package com.kdjj.local.dataSource
 
+import android.media.ExifInterface
+import com.kdjj.data.common.errorMap
 import com.kdjj.data.datasource.RecipeImageLocalDataSource
 import com.kdjj.local.FileSaveHelper
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.IOException
 import javax.inject.Inject
 
 internal class RecipeImageLocalDataSourceImpl @Inject constructor(
     private val fileSaveHelper: FileSaveHelper
 ) : RecipeImageLocalDataSource {
-    
+
     override suspend fun convertToByteArray(
         uri: String
     ): Result<ByteArray> {
         return fileSaveHelper.convertToByteArray(uri)
     }
-    
+
     override suspend fun convertToInternalStorageUri(
         byteArray: ByteArray,
         fileName: String
     ): Result<String> {
         return fileSaveHelper.convertToInternalStorageUri(byteArray, fileName)
     }
+
+    override suspend fun copyExif(
+        oldPath: String,
+        newPath: String
+    ): Result<Unit> =
+        withContext(Dispatchers.IO) {
+            kotlin.runCatching {
+                val oldExif = ExifInterface(oldPath)
+                val exifOrientation = oldExif.getAttribute(ExifInterface.TAG_ORIENTATION)
+                exifOrientation?.let {
+                    val newExif = ExifInterface(newPath)
+                    newExif.setAttribute(ExifInterface.TAG_ORIENTATION, exifOrientation)
+                    newExif.saveAttributes()
+                }
+                return@runCatching
+            }.errorMap {
+                Exception(it.message)
+            }
+        }
 }
+

--- a/local/src/test/java/com/kdjj/local/dataSource/RecipeImageLocalDataSourceImplTest.kt
+++ b/local/src/test/java/com/kdjj/local/dataSource/RecipeImageLocalDataSourceImplTest.kt
@@ -14,39 +14,40 @@ class RecipeImageLocalDataSourceImplTest {
 	private lateinit var recipeImageLocalDataSourceImpl: RecipeImageLocalDataSourceImpl
 	private val testUri = "this is test uri"
 	private val testByteArray = testUri.toByteArray()
-	
+	private val testDegree = 90f
+	private val testPair = Pair(testByteArray, testDegree)
+
 	@Before
 	fun setup() {
 		mockFileSaveHelper = mock(FileSaveHelper::class.java)
 		recipeImageLocalDataSourceImpl = RecipeImageLocalDataSourceImpl(mockFileSaveHelper)
 	}
-	
+
 	@Test
-	fun convertToByteArray_getImageByteArray_true(): Unit = runBlocking {
+	fun convertToByteArray_getImageByteArrayAndImageDegree_true(): Unit = runBlocking {
 		//given
 		`when`(recipeImageLocalDataSourceImpl.convertToByteArray(testUri)).thenReturn(
-			Result.success(
-				testByteArray
-			)
+			Result.success(testByteArray to testDegree)
 		)
 		//when
-		val byteArrayResult = recipeImageLocalDataSourceImpl.convertToByteArray(testUri)
+		val result = recipeImageLocalDataSourceImpl.convertToByteArray(testUri)
 		//then
-		assertEquals(testByteArray, byteArrayResult.getOrNull())
+		assertEquals(testPair, result.getOrNull())
 	}
-	
+
 	@Test
 	fun convertToInternalStorageUri_localStorageImageUri_true(): Unit = runBlocking {
 		//given
 		`when`(
 			recipeImageLocalDataSourceImpl.convertToInternalStorageUri(
 				testByteArray,
-				"fileName"
+				"fileName",
+				testDegree
 			)
 		).thenReturn(Result.success(testUri))
 		//when
 		val newLocalImagePathResult =
-			recipeImageLocalDataSourceImpl.convertToInternalStorageUri(testByteArray, "fileName")
+			recipeImageLocalDataSourceImpl.convertToInternalStorageUri(testByteArray, "fileName", testDegree)
 		//then
 		assertEquals(testUri, newLocalImagePathResult.getOrNull())
 	}


### PR DESCRIPTION
## 개요
이미지가 저장될때 각도가 돌아가는 현상을 수정함

## 하고자 했던 것
- [x] FileSaveHalper에서 이미지 orientation 처리 기능 추가
- [x] RecipeImageLocalDataSource에 orientaiton 처리 함수 호출 메서드 추가
- [x] 기존 SaveRecipeUseCase에서 처리되던 이미지 저장 처리 RecipeImageRepository에서 하도록 수정
- [x] SaveRecipeUseCase에서 위와 같이 수정
- [x] 기존 RecipeImageRepository test, RecipeImageLocalDataSource test 수정 

## 변경 사항
UseCase에서 Image 저장 처리에되한 성공 여부를 관리하다 Repository 에서 하도록 변경

## 발생한 이슈
없음