### PR TITLE
[develop] 레시피 개요 페이지 디자인 구현

### DIFF
--- a/domain/src/main/java/com/kdjj/domain/di/UseCaseModule.kt
+++ b/domain/src/main/java/com/kdjj/domain/di/UseCaseModule.kt
@@ -6,6 +6,7 @@ import com.kdjj.domain.model.request.*
 import com.kdjj.domain.usecase.*
 import dagger.Binds
 import dagger.Module
+import kotlinx.coroutines.flow.Flow
 
 @Module
 abstract class UseCaseModule {
@@ -24,7 +25,7 @@ abstract class UseCaseModule {
     internal abstract fun bindFetchLocalLatestRecipeListUseCase(
         fetchLocalLatestRecipeListUseCase: FetchLocalLatestRecipeListUseCase
     ): UseCase<FetchLocalLatestRecipeListRequest, List<Recipe>>
-
+    
     @Binds
     internal abstract fun bindFechLocalTitleRecipeListUseCase(
         fetchLocalTitleRecipeListUseCase: FetchLocalTitleRecipeListUseCase
@@ -37,7 +38,7 @@ abstract class UseCaseModule {
     
     @Binds
     internal abstract fun bindFetchRecipeTypesUseCase(
-        fetchRecipeTypesUseCase: FetchRecipeTypesUseCase
+        fetchRecipeTypeListUseCase: FetchRecipeTypeListUseCase
     ): UseCase<EmptyRequest, List<RecipeType>>
     
     @Binds
@@ -84,4 +85,9 @@ abstract class UseCaseModule {
     internal abstract fun bindDeleteRemoteRecipeUseCase(
         deleteRemoteRecipeUseCase: DeleteRemoteRecipeUseCase
     ): UseCase<DeleteRemoteRecipeRequest, Unit>
+    
+    @Binds
+    internal abstract fun bindGetLocalRecipeFlowUseCase(
+        getLocalRecipeFlowUseCase: GetLocalRecipeFlowUseCase
+    ): UseCase<GetLocalRecipeFlowRequest, Flow<Recipe>>
 }

--- a/domain/src/main/java/com/kdjj/domain/model/request/GetLocalRecipeFlowRequest.kt
+++ b/domain/src/main/java/com/kdjj/domain/model/request/GetLocalRecipeFlowRequest.kt
@@ -1,5 +1,5 @@
 package com.kdjj.domain.model.request
 
-data class GetLocalRecipeRequest(
+data class GetLocalRecipeFlowRequest(
     val recipeId: String
 ) : Request

--- a/domain/src/main/java/com/kdjj/domain/usecase/FetchRecipeTypeListUseCase.kt
+++ b/domain/src/main/java/com/kdjj/domain/usecase/FetchRecipeTypeListUseCase.kt
@@ -5,7 +5,7 @@ import com.kdjj.domain.repository.RecipeTypeRepository
 import com.kdjj.domain.model.request.EmptyRequest
 import javax.inject.Inject
 
-class FetchRecipeTypesUseCase @Inject constructor(
+class FetchRecipeTypeListUseCase @Inject constructor(
 	private val recipeTypeRepository: RecipeTypeRepository
 ) : UseCase<EmptyRequest, @JvmSuppressWildcards List<RecipeType>> {
 	

--- a/domain/src/main/java/com/kdjj/domain/usecase/GetLocalRecipeFlowUseCase.kt
+++ b/domain/src/main/java/com/kdjj/domain/usecase/GetLocalRecipeFlowUseCase.kt
@@ -8,7 +8,7 @@ import javax.inject.Inject
 
 class GetLocalRecipeFlowUseCase @Inject constructor(
     private val recipeRepository: RecipeRepository
-) : UseCase<GetLocalRecipeFlowRequest, Flow<Recipe>> {
+) : UseCase<GetLocalRecipeFlowRequest, @JvmSuppressWildcards Flow<Recipe>> {
     
     override suspend fun invoke(request: GetLocalRecipeFlowRequest): Result<Flow<Recipe>> =
         recipeRepository.getLocalRecipeFlow(request.recipeId)

--- a/domain/src/main/java/com/kdjj/domain/usecase/GetLocalRecipeFlowUseCase.kt
+++ b/domain/src/main/java/com/kdjj/domain/usecase/GetLocalRecipeFlowUseCase.kt
@@ -1,15 +1,15 @@
 package com.kdjj.domain.usecase
 
 import com.kdjj.domain.model.Recipe
-import com.kdjj.domain.model.request.GetLocalRecipeRequest
+import com.kdjj.domain.model.request.GetLocalRecipeFlowRequest
 import com.kdjj.domain.repository.RecipeRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
-class GetLocalRecipeUseCase @Inject constructor(
+class GetLocalRecipeFlowUseCase @Inject constructor(
     private val recipeRepository: RecipeRepository
-) : UseCase<GetLocalRecipeRequest, Flow<Recipe>> {
+) : UseCase<GetLocalRecipeFlowRequest, Flow<Recipe>> {
     
-    override suspend fun invoke(request: GetLocalRecipeRequest): Result<Flow<Recipe>> =
+    override suspend fun invoke(request: GetLocalRecipeFlowRequest): Result<Flow<Recipe>> =
         recipeRepository.getLocalRecipeFlow(request.recipeId)
 }

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -8,6 +8,9 @@
 
     <application>
         <activity
+            android:name=".view.recipesummary.RecipeSummaryActivity"
+            android:exported="false" />
+        <activity
             android:name=".view.recipedetail.RecipeDetailActivity"
             android:exported="false" />
         <activity

--- a/presentation/src/main/java/com/kdjj/presentation/common/Utils.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/common/Utils.kt
@@ -2,14 +2,10 @@ package com.kdjj.presentation.common
 
 import com.kdjj.domain.model.Recipe
 
-
-internal fun calculateSeconds(min: Int, sec: Int): Int{
-    return min*60 + sec
+internal fun calculateSeconds(min: Int, sec: Int): Int {
+    return min * 60 + sec
 }
 
-internal fun calculateTotalTime(recipe: Recipe): String {
-    val secs = recipe.stepList.map { it.seconds }.reduce { acc, i -> acc + i }
-    val min = secs / 60
-    return if (min == 0) secs.toString() + "초"
-    else "$min 분 ${secs%60} 초"
+internal fun calculateTotalTime(recipe: Recipe?): Int {
+    return recipe?.let { it.stepList.map { it.seconds }.reduce { acc, i -> acc + i } } ?: 0
 }

--- a/presentation/src/main/java/com/kdjj/presentation/view/bindingadapter/TextViewBindingAdapter.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/bindingadapter/TextViewBindingAdapter.kt
@@ -4,36 +4,39 @@ import android.widget.TextView
 import androidx.databinding.BindingAdapter
 import com.kdjj.domain.model.Recipe
 import com.kdjj.presentation.R
-import com.kdjj.presentation.common.calculateTotalTime
-
-@BindingAdapter("calculateTotalTime")
-fun TextView.setTotalTimeText(recipe: Recipe?) {
-    val totalTime = calculateTotalTime(recipe ?: return)
-    this.text = "소요시간: $totalTime"
-}
 
 @BindingAdapter("formatTotalTime")
 fun TextView.formatTotalTime(totalTime: Int) {
     val min = totalTime / 60
     this.text = if (min == 0) context.getString(R.string.total_time_seconds, totalTime.toString())
-    else context.getString(R.string.total_time_min_seconds, min.toString(), (totalTime%60).toString())
+    else context.getString(R.string.total_time_min_seconds, min.toString(), (totalTime % 60).toString())
 }
 
 @BindingAdapter("calculateUpdateTime")
 fun TextView.calculateUpdateTime(createTime: Long) {
     val secs = (System.currentTimeMillis() - createTime) / 1000
-
+    
     // 분 60     시간 3600    하루 24 * 3600    1달 : 30 * 24 * 3600     1년 : 365 * 24 * 3600
     val year = secs / 31536000
     val month = secs / 2592000
     val day = secs / 86400
     val hour = secs / 3600
     val min = secs / 60
-
+    
     this.text = if (year != 0L) context.getString(R.string.update_time_year, year.toString())
     else if (month != 0L) context.getString(R.string.update_time_month, month.toString())
     else if (day != 0L) context.getString(R.string.update_time_day, day.toString())
     else if (hour != 0L) context.getString(R.string.update_time_hours, hour.toString())
     else if (min != 0L) context.getString(R.string.update_time_minutes, min.toString())
     else context.getString(R.string.update_time_seconds, secs.toString())
+}
+
+@BindingAdapter("setStepSummary")
+fun TextView.setStepSummary(recipe: Recipe?) {
+    recipe ?: return
+    val stepSummaryText = recipe.stepList
+        .fold("") { acc, recipeStep ->
+            acc + "${recipeStep.name}\n"
+        }
+    this.text = stepSummaryText
 }

--- a/presentation/src/main/java/com/kdjj/presentation/view/recipesummary/RecipeSummaryActivity.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/recipesummary/RecipeSummaryActivity.kt
@@ -1,0 +1,24 @@
+package com.kdjj.presentation.view.recipesummary
+
+import android.os.Bundle
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.databinding.DataBindingUtil
+import com.kdjj.presentation.R
+import com.kdjj.presentation.databinding.ActivityRecipeSummaryBinding
+import com.kdjj.presentation.viewmodel.recipesummary.RecipeSummaryViewModel
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class RecipeSummaryActivity : AppCompatActivity() {
+    
+    private lateinit var binding: ActivityRecipeSummaryBinding
+    private val recipeSummaryViewModel: RecipeSummaryViewModel by viewModels()
+    
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = DataBindingUtil.setContentView(this, R.layout.activity_recipe_summary)
+        binding.viewModel = recipeSummaryViewModel
+        binding.lifecycleOwner = this
+    }
+}

--- a/presentation/src/main/java/com/kdjj/presentation/view/recipesummary/RecipeSummaryActivity.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/recipesummary/RecipeSummaryActivity.kt
@@ -17,8 +17,11 @@ class RecipeSummaryActivity : AppCompatActivity() {
     
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        
         binding = DataBindingUtil.setContentView(this, R.layout.activity_recipe_summary)
         binding.viewModel = recipeSummaryViewModel
         binding.lifecycleOwner = this
+        
+        setSupportActionBar(binding.toolbarSummary)
     }
 }

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipesummary/RecipeSummaryViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipesummary/RecipeSummaryViewModel.kt
@@ -1,8 +1,39 @@
 package com.kdjj.presentation.viewmodel.recipesummary
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.kdjj.domain.model.Recipe
+import com.kdjj.domain.model.RecipeType
+import com.kdjj.domain.model.request.EmptyRequest
+import com.kdjj.domain.model.request.GetLocalRecipeFlowRequest
+import com.kdjj.domain.usecase.UseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @HiltViewModel
-class RecipeSummaryViewModel: ViewModel() {
+class RecipeSummaryViewModel @Inject constructor(
+    private val getRecipeFlowUseCase: UseCase<GetLocalRecipeFlowRequest, Flow<Recipe>>,
+) : ViewModel() {
+    
+    private val _liveRecipe = MutableLiveData<Recipe>()
+    val liveRecipe: LiveData<Recipe> = _liveRecipe
+    private var isInitialized = false
+    
+    fun initViewModel(recipeId: String) {
+        if (isInitialized) return
+        viewModelScope.launch {
+            getRecipeFlowUseCase(GetLocalRecipeFlowRequest(recipeId))
+                .onSuccess { recipeFlow ->
+                    recipeFlow.collect { recipe ->
+                        _liveRecipe.value = recipe
+                    }
+                }
+        }
+        isInitialized = true
+    }
 }

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipesummary/RecipeSummaryViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipesummary/RecipeSummaryViewModel.kt
@@ -1,0 +1,8 @@
+package com.kdjj.presentation.viewmodel.recipesummary
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+
+@HiltViewModel
+class RecipeSummaryViewModel: ViewModel() {
+}

--- a/presentation/src/main/res/layout/activity_recipe_detail.xml
+++ b/presentation/src/main/res/layout/activity_recipe_detail.xml
@@ -136,7 +136,7 @@
                     android:id="@+id/textView_detail_timerDescription"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@{@string/expectedTime(viewModel.liveSelectedStep.seconds / 60, viewModel.liveSelectedStep.seconds % 60)}"
+                    android:text="@{@string/expectedTimeMinSec(viewModel.liveSelectedStep.seconds / 60, viewModel.liveSelectedStep.seconds % 60)}"
                     android:textSize="@dimen/detail_timerDescription_textSize"
                     android:textColor="@color/light_100"
                     android:layout_margin="@dimen/detail_timerDescription_margin"

--- a/presentation/src/main/res/layout/activity_recipe_summary.xml
+++ b/presentation/src/main/res/layout/activity_recipe_summary.xml
@@ -8,6 +8,8 @@
         <variable
             name="viewModel"
             type="com.kdjj.presentation.viewmodel.recipesummary.RecipeSummaryViewModel" />
+
+        <import type="com.kdjj.presentation.common.UtilsKt" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -28,8 +30,9 @@
             android:id="@+id/imageView_summary_recipeImage"
             android:layout_width="match_parent"
             android:layout_height="250dp"
+            app:loadImage="@{viewModel.liveRecipe.imgPath}"
+            android:scaleType="centerCrop"
             android:contentDescription="@string/recipeImage"
-            android:src="@drawable/ic_baseline_fastfood_24"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/toolbar_summary"
             tools:src="@drawable/ic_baseline_fastfood_24" />
@@ -52,6 +55,7 @@
         <TextView
             android:id="@+id/textView_summary_expectedTime"
             style="@style/SummaryText"
+            formatTotalTime="@{UtilsKt.calculateTotalTime(viewModel.liveRecipe)}"
             app:layout_constraintStart_toEndOf="@id/textView_summary_expectedTimeLabel"
             app:layout_constraintTop_toTopOf="@id/textView_summary_expectedTimeLabel"
             tools:text="40분" />
@@ -73,6 +77,7 @@
         <TextView
             android:id="@+id/textView_summary_ingredient"
             style="@style/SummaryText"
+            android:text="@{viewModel.liveRecipe.stuff}"
             app:layout_constraintLeft_toRightOf="@id/textView_summary_ingredientLabel"
             app:layout_constraintTop_toTopOf="@id/textView_summary_ingredientLabel"
             tools:text="이것 저것 머시기\n이것 저것 머시기\n이것 저것 머시기\n이것 저것 머시기" />
@@ -94,6 +99,7 @@
         <TextView
             android:id="@+id/textView_summary_stepSummary"
             style="@style/SummaryText"
+            setStepSummary="@{viewModel.liveRecipe}"
             app:layout_constraintLeft_toRightOf="@id/textView_summary_stepSummaryLabel"
             app:layout_constraintTop_toTopOf="@id/textView_summary_stepSummaryLabel"
             tools:text="재료 준비\n면 삶기\n고기 볶기" />

--- a/presentation/src/main/res/layout/activity_recipe_summary.xml
+++ b/presentation/src/main/res/layout/activity_recipe_summary.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
 
@@ -8,11 +10,116 @@
             type="com.kdjj.presentation.viewmodel.recipesummary.RecipeSummaryViewModel" />
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context=".view.recipesummary.RecipeSummaryActivity">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar_summary"
+            style="@style/Toolbar"
+            android:layout_width="0dp"
+            android:layout_height="?attr/actionBarSize"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageView
+            android:id="@+id/imageView_summary_recipeImage"
+            android:layout_width="match_parent"
+            android:layout_height="250dp"
+            android:contentDescription="@string/recipeImage"
+            android:src="@drawable/ic_baseline_fastfood_24"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/toolbar_summary"
+            tools:src="@drawable/ic_baseline_fastfood_24" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/barrier_summary_recipeImage"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierDirection="bottom"
+            app:constraint_referenced_ids="imageView_summary_recipeImage" />
+
+        <TextView
+            android:id="@+id/textView_summary_expectedTimeLabel"
+            style="@style/SummaryLabel"
+            android:text="@string/expectedTime"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/barrier_summary_recipeImage" />
+
+
+        <TextView
+            android:id="@+id/textView_summary_expectedTime"
+            style="@style/SummaryText"
+            app:layout_constraintStart_toEndOf="@id/textView_summary_expectedTimeLabel"
+            app:layout_constraintTop_toTopOf="@id/textView_summary_expectedTimeLabel"
+            tools:text="40분" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/barrier_summary_expectedTime"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierDirection="bottom"
+            app:constraint_referenced_ids="textView_summary_expectedTime, textView_summary_expectedTimeLabel" />
+
+        <TextView
+            android:id="@+id/textView_summary_ingredientLabel"
+            style="@style/SummaryLabel"
+            android:text="@string/ingredient"
+            app:layout_constraintEnd_toEndOf="@id/textView_summary_expectedTimeLabel"
+            app:layout_constraintTop_toBottomOf="@id/barrier_summary_expectedTime" />
+
+        <TextView
+            android:id="@+id/textView_summary_ingredient"
+            style="@style/SummaryText"
+            app:layout_constraintLeft_toRightOf="@id/textView_summary_ingredientLabel"
+            app:layout_constraintTop_toTopOf="@id/textView_summary_ingredientLabel"
+            tools:text="이것 저것 머시기\n이것 저것 머시기\n이것 저것 머시기\n이것 저것 머시기" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/barrier_summary_ingredient"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierDirection="bottom"
+            app:constraint_referenced_ids="textView_summary_ingredient, textView_summary_ingredientLabel" />
+
+        <TextView
+            android:id="@+id/textView_summary_stepSummaryLabel"
+            style="@style/SummaryLabel"
+            android:text="@string/stepSummary"
+            app:layout_constraintEnd_toEndOf="@id/textView_summary_ingredientLabel"
+            app:layout_constraintTop_toBottomOf="@id/barrier_summary_ingredient" />
+
+        <TextView
+            android:id="@+id/textView_summary_stepSummary"
+            style="@style/SummaryText"
+            app:layout_constraintLeft_toRightOf="@id/textView_summary_stepSummaryLabel"
+            app:layout_constraintTop_toTopOf="@id/textView_summary_stepSummaryLabel"
+            tools:text="재료 준비\n면 삶기\n고기 볶기" />
+
+
+        <androidx.cardview.widget.CardView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/bottomButton_margin"
+            app:cardCornerRadius="@dimen/bottomButton_corner"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@drawable/bg_btn_bottom"
+                android:clickable="true"
+                android:focusable="true"
+                android:gravity="center"
+                android:padding="@dimen/bottomButton_padding"
+                android:text="@string/showRecipe"
+                android:textColor="@color/light_100"
+                android:textSize="@dimen/bottomButton_textSize" />
+        </androidx.cardview.widget.CardView>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/presentation/src/main/res/layout/activity_recipe_summary.xml
+++ b/presentation/src/main/res/layout/activity_recipe_summary.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.kdjj.presentation.viewmodel.recipesummary.RecipeSummaryViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".view.recipesummary.RecipeSummaryActivity">
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/presentation/src/main/res/layout/item_my_recipe.xml
+++ b/presentation/src/main/res/layout/item_my_recipe.xml
@@ -85,7 +85,6 @@
                     android:layout_marginTop="@dimen/myRecipe_textView_title_marginTop"
                     android:textColor="@color/light_300"
                     android:textSize="@dimen/myRecipe_textView_timeSize"
-                    calculateTotalTime="@{myRecipeItem.recipe}"
                     app:layout_constraintBottom_toTopOf="@id/textView_myRecipe_description"
                     app:layout_constraintLeft_toLeftOf="parent"
                     app:layout_constraintRight_toRightOf="parent"

--- a/presentation/src/main/res/values/dimens.xml
+++ b/presentation/src/main/res/values/dimens.xml
@@ -77,4 +77,10 @@
     <dimen name="detail_stepItem_paddingVertical">8dp</dimen>
     <dimen name="detail_stepItem_paddingHorizontal">16dp</dimen>
 
+    <dimen name="summary_expectedTimeLabel_marginStart">16dp</dimen>
+    <dimen name="summary_expectedTimeLabel_marginTop">24dp</dimen>
+    <dimen name="summary_expectedTime_marginStart">16dp</dimen>
+    <dimen name="summary_label_textSize">16sp</dimen>
+    <dimen name="summary_text_textSize">14sp</dimen>
+
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -34,7 +34,7 @@
     <string name="others_orderByPopular">인기순</string>
     <string name="others">힐끔보기</string>
     <string name="startTimer">타이머 시작</string>
-    <string name="expectedTime">예상 소요 시간: %s분 %s초</string>
+    <string name="expectedTimeMinSec">예상 소요 시간: %s분 %s초</string>
     <string name="timerMinSec">%02d:%02d</string>
 
     <string name="total_time">소요시간</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -46,4 +46,9 @@
     <string name="update_time_hours">%s시간 전</string>
     <string name="update_time_minutes">%s분 전</string>
     <string name="update_time_seconds">%s초 전</string>
+
+    <string name="showRecipe">레시피 보기</string>
+    <string name="expectedTime">예상 소요시간</string>
+    <string name="ingredient">재료</string>
+    <string name="stepSummary">한눈에 보기</string>
 </resources>

--- a/presentation/src/main/res/values/styles.xml
+++ b/presentation/src/main/res/values/styles.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+
     <style name="Toolbar" parent="Widget.AppCompat.Toolbar">
         <item name="android:background">@color/blue_600</item>
         <item name="titleTextColor">@color/light_100</item>
@@ -21,5 +22,23 @@
         <item name="android:textColor">@color/dark_500</item>
         <item name="android:textSize">@dimen/editor_inputLabel_textSize</item>
         <item name="android:layout_marginStart">@dimen/editor_inputLabel_marginStart</item>
+    </style>
+
+    <style name="SummaryLabel" parent="Widget.AppCompat.TextView">
+        <item name="android:textColor">@color/dark_500</item>
+        <item name="android:textSize">@dimen/summary_label_textSize</item>
+        <item name="android:textStyle">bold</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_marginTop">@dimen/summary_expectedTimeLabel_marginTop</item>
+        <item name="android:layout_marginStart">@dimen/summary_expectedTimeLabel_marginStart</item>
+    </style>
+
+    <style name="SummaryText" parent="Widget.AppCompat.TextView">
+        <item name="android:textColor">@color/dark_500</item>
+        <item name="android:textSize">@dimen/summary_text_textSize</item>
+        <item name="android:layout_marginStart">@dimen/summary_expectedTime_marginStart</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_width">wrap_content</item>
     </style>
 </resources>


### PR DESCRIPTION
## 개요
Issue #103 
<img src="https://user-images.githubusercontent.com/56161518/142218714-506f3069-504f-42af-a2c0-a31bd2819691.png" width="50%"/>

## 하고자 했던 것
- 레시피 개요 페이지 생성
- 레시피 개요 페이지 디자인 추가

## 변경 사항
- [x] 레시피 개요 페이지 생성
- [x] 레시피 개요 페이지 디자인 구현
- [x] 불필요한 BindingAdapter 삭제
- [x] GetRecipeUseCase -> GetRecipeFlowUseCase 네이밍 변경
- [x] FetchRecipeTypesUseCase -> FetchRecipeTypeListUseCase 네이밍 변경
- [x] calculateTotalTime 반환형 String -> Int로 변경


## 발생한 이슈
