### PR TITLE
[develop] 힐끔 보기 화면에서 레시피 개요 화면으로 이동 #112

### DIFF
--- a/presentation/src/main/java/com/kdjj/presentation/model/OthersRecipeModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/model/OthersRecipeModel.kt
@@ -1,6 +1,7 @@
 package com.kdjj.presentation.model
 
 import com.kdjj.domain.model.Recipe
+import com.kdjj.domain.model.RecipeState
 
 data class OthersRecipeModel(
     val recipeId: String,
@@ -10,6 +11,7 @@ data class OthersRecipeModel(
     val viewCount: Int,
     val imgPath: String,
     val createTime: Long,
+    val state: RecipeState,
 )
 
 internal fun Recipe.toOthersRecipeModel() =
@@ -20,5 +22,6 @@ internal fun Recipe.toOthersRecipeModel() =
         stuff,
         viewCount,
         imgPath,
-        createTime
+        createTime,
+        state
     )

--- a/presentation/src/main/java/com/kdjj/presentation/view/adapter/OthersRecipeListAdapter.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/adapter/OthersRecipeListAdapter.kt
@@ -5,8 +5,10 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import com.kdjj.presentation.databinding.ItemOthersRecipeBinding
 import com.kdjj.presentation.model.OthersRecipeModel
+import com.kdjj.presentation.viewmodel.others.OthersViewModel
 
 class OthersRecipeListAdapter(
+    private val viewModel: OthersViewModel,
 ) : SingleViewTypeListAdapter<OthersRecipeModel, ItemOthersRecipeBinding>(OthersRecipeModelDiffCallback()) {
 
     override fun createBinding(parent: ViewGroup): ItemOthersRecipeBinding =
@@ -17,7 +19,7 @@ class OthersRecipeListAdapter(
         getItemPosition: () -> Int,
     ) {
         binding.root.setOnClickListener {
-            //todo: clicklisntener
+            viewModel.recipeItemClick(getItem(getItemPosition()))
         }
     }
 

--- a/presentation/src/main/java/com/kdjj/presentation/view/home/others/OthersRecipeFragment.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/home/others/OthersRecipeFragment.kt
@@ -6,6 +6,7 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.os.bundleOf
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.viewModels
 import androidx.navigation.Navigation
@@ -17,6 +18,8 @@ import com.kdjj.domain.model.exception.ApiException
 import com.kdjj.domain.model.exception.NetworkException
 import com.kdjj.presentation.R
 import com.kdjj.presentation.common.EventObserver
+import com.kdjj.presentation.common.RECIPE_ID
+import com.kdjj.presentation.common.RECIPE_STATE
 import com.kdjj.presentation.databinding.FragmentOthersRecipeBinding
 import com.kdjj.presentation.view.adapter.OthersRecipeListAdapter
 import com.kdjj.presentation.viewmodel.others.OthersViewModel
@@ -47,6 +50,7 @@ class OthersRecipeFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         observeNetworkEvent()
         observeMoveToSearchEvent()
+        observeRecipeItemClickEvent()
         setAdapter()
         setSwipeRefreshLayout()
         setBinding()
@@ -77,7 +81,7 @@ class OthersRecipeFragment : Fragment() {
     }
 
     private fun setAdapter() {
-        val adapter = OthersRecipeListAdapter()
+        val adapter = OthersRecipeListAdapter(viewModel)
 
         with(binding) {
             recyclerViewOthersRecipe.adapter = adapter
@@ -128,7 +132,22 @@ class OthersRecipeFragment : Fragment() {
         })
     }
 
+    private fun observeRecipeItemClickEvent() {
+        viewModel.eventRecipeItemClicked.observe(viewLifecycleOwner, EventObserver {
+            val bundle = bundleOf(
+                RECIPE_ID to it.recipeId,
+                RECIPE_STATE to it.state
+            )
+            navigation.navigate(R.id.action_othersFragment_to_recipeSummaryActivity, bundle)
+        })
+    }
+
     private fun showSnackBar(msg: String) {
         Snackbar.make(binding.root, msg, Snackbar.LENGTH_LONG).show()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/presentation/src/main/java/com/kdjj/presentation/view/home/others/OthersRecipeFragment.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/home/others/OthersRecipeFragment.kt
@@ -117,10 +117,10 @@ class OthersRecipeFragment : Fragment() {
         viewModel.eventException.observe(viewLifecycleOwner, EventObserver {
             when (it) {
                 is NetworkException -> {
-                    showSnackBar("네트워크와 연결이 끊어졌습니다.")
+                    showSnackBar(getString(R.string.networkErrorMessage))
                 }
                 is ApiException -> {
-                    showSnackBar("서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요.")
+                    showSnackBar(getString(R.string.severErrorMessage))
                 }
             }
         })

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/others/OthersViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/others/OthersViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kdjj.domain.model.Recipe
-import com.kdjj.domain.model.exception.NetworkException
 import com.kdjj.domain.model.request.FetchRemoteLatestRecipeListRequest
 import com.kdjj.domain.model.request.FetchRemotePopularRecipeListRequest
 import com.kdjj.domain.usecase.UseCase
@@ -15,9 +14,7 @@ import com.kdjj.presentation.model.OthersRecipeModel
 import com.kdjj.presentation.model.toOthersRecipeModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
-import java.lang.Exception
 import javax.inject.Inject
 
 @HiltViewModel
@@ -46,6 +43,9 @@ class OthersViewModel @Inject constructor(
 
     private var _eventSearchIconClicked = MutableLiveData<Event<Unit>>()
     val eventSearchIconClicked: LiveData<Event<Unit>> get() = _eventSearchIconClicked
+
+    private var _eventRecipeItemClicked = MutableLiveData<Event<OthersRecipeModel>>()
+    val eventRecipeItemClicked: LiveData<Event<OthersRecipeModel>> get() = _eventRecipeItemClicked
 
     init {
         Log.d("Test", "OthersViewModel init")
@@ -140,6 +140,10 @@ class OthersViewModel @Inject constructor(
 
     fun moveToRecipeSearchFragment() {
         _eventSearchIconClicked.value = Event(Unit)
+    }
+
+    fun recipeItemClick(recipeModel: OthersRecipeModel) {
+        _eventRecipeItemClicked.value = Event(recipeModel)
     }
 
     enum class OthersSortType {

--- a/presentation/src/main/res/navigation/navigation.xml
+++ b/presentation/src/main/res/navigation/navigation.xml
@@ -33,6 +33,9 @@
         <action
             android:id="@+id/action_othersFragment_to_searchRecipeFragment"
             app:destination="@id/searchRecipeFragment" />
+        <action
+            android:id="@+id/action_othersFragment_to_recipeSummaryActivity"
+            app:destination="@id/recipeSummaryActivity" />
     </fragment>
     <activity
         android:id="@+id/recipeEditorActivity"

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -51,4 +51,7 @@
     <string name="expectedTime">예상 소요시간</string>
     <string name="ingredient">재료</string>
     <string name="stepSummary">한눈에 보기</string>
+
+    <string name="networkErrorMessage">네트워크와 연결이 끊어졌습니다.</string>
+    <string name="severErrorMessage">서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요.</string>
 </resources>


### PR DESCRIPTION
## 개요
Issue: https://github.com/boostcampwm-2021/Android08-Ratatouille/issues/112
## 하고자 했던 것
힐끔 보기 화면에서 레시피 개요 화면 이동 
## 변경 사항
- [x] 화면 이동 6a7b7631133b2d6ca51135f692a18a12144c5ee5
## 발생한 이슈
