### PR TITLE
[develop] 내 레시피 화면 레시피 추가, 삭제, 수정시 레시피 목록 초기화

### DIFF
--- a/data/src/main/java/com/kdjj/data/repository/RecipeRepositoryImpl.kt
+++ b/data/src/main/java/com/kdjj/data/repository/RecipeRepositoryImpl.kt
@@ -5,29 +5,38 @@ import com.kdjj.data.datasource.RecipeRemoteDataSource
 import com.kdjj.domain.model.Recipe
 import com.kdjj.domain.repository.RecipeRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import javax.inject.Inject
 
 internal class RecipeRepositoryImpl @Inject constructor(
     private val recipeLocalDataSource: RecipeLocalDataSource,
     private val recipeRemoteDataSource: RecipeRemoteDataSource
 ) : RecipeRepository {
-    
+
+    private val isUpdated = MutableStateFlow(0)
+
     override suspend fun saveLocalRecipe(
         recipe: Recipe
     ): Result<Boolean> {
-        return recipeLocalDataSource.saveRecipe(recipe)
+        return recipeLocalDataSource.saveRecipe(recipe).also {
+            it.onSuccess { isUpdated.value++ }
+        }
     }
     
     override suspend fun updateLocalRecipe(
         recipe: Recipe
     ): Result<Boolean> {
-        return recipeLocalDataSource.updateRecipe(recipe)
+        return recipeLocalDataSource.updateRecipe(recipe).also {
+            it.onSuccess { isUpdated.value++ }
+        }
     }
     
     override suspend fun deleteLocalRecipe(
         recipe: Recipe
     ): Result<Boolean> {
-        return recipeLocalDataSource.deleteRecipe(recipe)
+        return recipeLocalDataSource.deleteRecipe(recipe).also {
+            it.onSuccess { isUpdated.value++ }
+        }
     }
     
     override suspend fun uploadRecipe(
@@ -52,5 +61,9 @@ internal class RecipeRepositoryImpl @Inject constructor(
         recipeId: String
     ): Result<Flow<Recipe>> {
         return recipeLocalDataSource.getRecipeFlow(recipeId)
+    }
+
+    override fun getRecipeUpdateState(): Result<Flow<Int>> {
+        return  Result.success(isUpdated)
     }
 }

--- a/domain/src/main/java/com/kdjj/domain/di/UseCaseModule.kt
+++ b/domain/src/main/java/com/kdjj/domain/di/UseCaseModule.kt
@@ -90,4 +90,9 @@ abstract class UseCaseModule {
     internal abstract fun bindGetLocalRecipeFlowUseCase(
         getLocalRecipeFlowUseCase: GetLocalRecipeFlowUseCase
     ): UseCase<GetLocalRecipeFlowRequest, Flow<Recipe>>
+
+    @Binds
+    internal abstract fun bindGetRecipeUpdateStateUseCase(
+        getRecipeUpdateStateUseCase: GetRecipeUpdateStateUseCase
+    ): UseCase<EmptyRequest, Flow<Int>>
 }

--- a/domain/src/main/java/com/kdjj/domain/repository/RecipeRepository.kt
+++ b/domain/src/main/java/com/kdjj/domain/repository/RecipeRepository.kt
@@ -2,6 +2,7 @@ package com.kdjj.domain.repository
 
 import com.kdjj.domain.model.Recipe
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
 interface RecipeRepository {
@@ -33,4 +34,6 @@ interface RecipeRepository {
     fun getLocalRecipeFlow(
         recipeId: String
     ): Result<Flow<Recipe>>
+
+    fun getRecipeUpdateState(): Result<Flow<Int>>
 }

--- a/domain/src/main/java/com/kdjj/domain/usecase/GetRecipeUpdateStateUseCase.kt
+++ b/domain/src/main/java/com/kdjj/domain/usecase/GetRecipeUpdateStateUseCase.kt
@@ -1,0 +1,15 @@
+package com.kdjj.domain.usecase
+
+import com.kdjj.domain.model.request.EmptyRequest
+import com.kdjj.domain.repository.RecipeRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetRecipeUpdateStateUseCase @Inject constructor(
+    private val recipeRepository: RecipeRepository
+): UseCase<EmptyRequest, @kotlin.jvm.JvmSuppressWildcards Flow<Int>> {
+
+    override suspend fun invoke(request: EmptyRequest): Result<Flow<Int>> {
+        return recipeRepository.getRecipeUpdateState()
+    }
+}

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/my/MyRecipeViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/my/MyRecipeViewModel.kt
@@ -179,7 +179,7 @@ internal class MyRecipeViewModel @Inject constructor(
 
     private fun hideProgress() {
         _liveRecipeItemList.value?.let {
-            if (it.isNotEmpty()) {
+            if (it.lastOrNull() == MyRecipeItem.Progress) {
                 _liveRecipeItemList.value = it.subList(0, it.size - 1)
             }
         }


### PR DESCRIPTION
## 개요
레시피 추가, 삭제, 수정을 담당하는 Repository에 상태를 Recipe 업데이트 상태를 관찰하는 flow를 만들고 이를 MyRecipeViewModel에서 collect 시켜 추가, 삭제, 수정 작업이 발생하면 Update된 레시피 목록을 새로 로드하게 함

## 하고자 했던 것
- [x] RecipeRepository flow 변수 추가 후 Recipe 업데이트 유/무 상태를 확인하여 내 레시피 화면 새로고침 

## 변경 사항
presentation 레이어로 RecipeRepository로 부터 해당 flow를 불러오는 Usecase를 추가함

## 발생한 이슈
없음