### PR TITLE
[develop ]  Remote에서 레시피 정보 불러오기, 로컬에 저장 

### DIFF
--- a/data/src/main/java/com/kdjj/data/datasource/RecipeRemoteDataSource.kt
+++ b/data/src/main/java/com/kdjj/data/datasource/RecipeRemoteDataSource.kt
@@ -3,16 +3,20 @@ package com.kdjj.data.datasource
 import com.kdjj.domain.model.Recipe
 
 interface RecipeRemoteDataSource {
-    
+
     suspend fun uploadRecipe(
         recipe: Recipe
     ): Result<Unit>
-    
+
     suspend fun increaseViewCount(
         recipe: Recipe
     ): Result<Unit>
-    
+
     suspend fun deleteRecipe(
         recipe: Recipe
     ): Result<Unit>
+
+    suspend fun fetchRecipe(
+        recipeID: String
+    ): Result<Recipe>
 }

--- a/data/src/main/java/com/kdjj/data/repository/RecipeRepositoryImpl.kt
+++ b/data/src/main/java/com/kdjj/data/repository/RecipeRepositoryImpl.kt
@@ -63,6 +63,10 @@ internal class RecipeRepositoryImpl @Inject constructor(
         return recipeLocalDataSource.getRecipeFlow(recipeId)
     }
 
+    override suspend fun fetchRemoteRecipe(recipeID: String): Result<Recipe> {
+        return recipeRemoteDataSource.fetchRecipe(recipeID)
+    }
+
     override fun getRecipeUpdateState(): Result<Flow<Int>> {
         return  Result.success(isUpdated)
     }

--- a/domain/src/main/java/com/kdjj/domain/di/UseCaseModule.kt
+++ b/domain/src/main/java/com/kdjj/domain/di/UseCaseModule.kt
@@ -95,4 +95,9 @@ abstract class UseCaseModule {
     internal abstract fun bindGetRecipeUpdateStateUseCase(
         getRecipeUpdateStateUseCase: GetRecipeUpdateStateUseCase
     ): UseCase<EmptyRequest, Flow<Int>>
+
+    @Binds
+    internal abstract fun bindFetchRemoteRecipeUseCase(
+        fetchRemoteRecipeUseCase: FetchRemoteRecipeUseCase
+    ): UseCase<FetchRemoteRecipeRequest, Recipe>
 }

--- a/domain/src/main/java/com/kdjj/domain/model/request/FetchRemoteRecipeRequest.kt
+++ b/domain/src/main/java/com/kdjj/domain/model/request/FetchRemoteRecipeRequest.kt
@@ -1,0 +1,7 @@
+package com.kdjj.domain.model.request
+
+import com.kdjj.domain.model.Recipe
+
+data class FetchRemoteRecipeRequest(
+    val recipeID: String
+): Request

--- a/domain/src/main/java/com/kdjj/domain/repository/RecipeRepository.kt
+++ b/domain/src/main/java/com/kdjj/domain/repository/RecipeRepository.kt
@@ -6,34 +6,38 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
 interface RecipeRepository {
-    
+
     suspend fun saveLocalRecipe(
         recipe: Recipe
     ): Result<Boolean>
-    
+
     suspend fun updateLocalRecipe(
         recipe: Recipe
     ): Result<Boolean>
-    
+
     suspend fun deleteLocalRecipe(
         recipe: Recipe
     ): Result<Boolean>
-    
+
     suspend fun uploadRecipe(
         recipe: Recipe
     ): Result<Unit>
-    
+
     suspend fun increaseRemoteRecipeViewCount(
         recipe: Recipe
     ): Result<Unit>
-    
+
     suspend fun deleteRemoteRecipe(
         recipe: Recipe
     ): Result<Unit>
-    
+
     fun getLocalRecipeFlow(
         recipeId: String
     ): Result<Flow<Recipe>>
+
+    suspend fun fetchRemoteRecipe(
+        recipeID: String
+    ): Result<Recipe>
 
     fun getRecipeUpdateState(): Result<Flow<Int>>
 }

--- a/domain/src/main/java/com/kdjj/domain/usecase/FetchRemoteRecipeUseCase.kt
+++ b/domain/src/main/java/com/kdjj/domain/usecase/FetchRemoteRecipeUseCase.kt
@@ -1,0 +1,14 @@
+package com.kdjj.domain.usecase
+
+import com.kdjj.domain.model.Recipe
+import com.kdjj.domain.model.request.FetchRemoteRecipeRequest
+import com.kdjj.domain.repository.RecipeRepository
+import javax.inject.Inject
+
+internal class FetchRemoteRecipeUseCase @Inject constructor(
+    private val recipeRepository: RecipeRepository
+) :UseCase<FetchRemoteRecipeRequest, @JvmSuppressWildcards Recipe> {
+
+    override suspend fun invoke(request: FetchRemoteRecipeRequest): Result<Recipe> =
+        recipeRepository.fetchRemoteRecipe(request.recipeID)
+}

--- a/domain/src/main/java/com/kdjj/domain/usecase/SaveLocalRecipeUseCase.kt
+++ b/domain/src/main/java/com/kdjj/domain/usecase/SaveLocalRecipeUseCase.kt
@@ -9,28 +9,38 @@ internal class SaveLocalRecipeUseCase @Inject constructor(
     private val recipeRepository: RecipeRepository,
     private val imageRepository: RecipeImageRepository
 ) : UseCase<SaveLocalRecipeRequest, Boolean> {
-    
+
     override suspend fun invoke(request: SaveLocalRecipeRequest): Result<Boolean> =
         kotlin.runCatching {
             val recipe = request.recipe
             val recipeImageUri = when (recipe.imgPath.isNotEmpty()) {
                 true -> {
-                    imageRepository.copyExternalImageToInternal(recipe.imgPath, recipe.recipeId)
-                        .getOrThrow()
+                    if (recipe.imgPath.startsWith("https://") || recipe.imgPath.startsWith("gs://")) {
+                        imageRepository.copyRemoteImageToInternal(recipe.imgPath, recipe.recipeId)
+                            .getOrThrow()
+                    } else {
+                        imageRepository.copyExternalImageToInternal(recipe.imgPath, recipe.recipeId)
+                            .getOrThrow()
+                    }
                 }
                 false -> ""
             }
             val recipeStepList = recipe.stepList.map { step ->
                 val stepImageUri = when (step.imgPath.isNotEmpty()) {
                     true -> {
-                        imageRepository.copyExternalImageToInternal(step.imgPath, step.stepId)
-                            .getOrThrow()
+                        if (recipe.imgPath.startsWith("https://") || recipe.imgPath.startsWith("gs://")) {
+                            imageRepository.copyRemoteImageToInternal(step.imgPath, step.stepId)
+                                .getOrThrow()
+                        } else {
+                            imageRepository.copyExternalImageToInternal(step.imgPath, step.stepId)
+                                .getOrThrow()
+                        }
                     }
                     false -> ""
                 }
                 step.copy(imgPath = stepImageUri)
             }
-            
+
             recipeRepository.saveLocalRecipe(
                 recipe.copy(
                     imgPath = recipeImageUri,

--- a/remote/src/main/java/com/kdjj/remote/dao/RecipeServiceImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/dao/RecipeServiceImpl.kt
@@ -1,17 +1,24 @@
 package com.kdjj.remote.dao
 
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.ktx.toObject
 import com.kdjj.domain.model.Recipe
+import com.kdjj.domain.model.exception.ApiException
+import com.kdjj.domain.model.exception.NetworkException
+import com.kdjj.remote.dto.RecipeDto
+import com.kdjj.remote.dto.toDomain
 import com.kdjj.remote.dto.toDto
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
+import kotlin.coroutines.resumeWithException
 
 internal class RecipeServiceImpl @Inject constructor(
     private val firestore: FirebaseFirestore
 ) : RemoteRecipeService {
-    
+
     override suspend fun uploadRecipe(recipe: Recipe): Unit =
         withContext(Dispatchers.IO) {
             firestore.collection(RECIPE_COLLECTION_ID)
@@ -19,7 +26,7 @@ internal class RecipeServiceImpl @Inject constructor(
                 .set(recipe.toDto())
                 .await()
         }
-    
+
     override suspend fun increaseViewCount(recipe: Recipe): Unit =
         withContext(Dispatchers.IO) {
             val documentRefer = firestore.collection(RECIPE_COLLECTION_ID)
@@ -30,17 +37,37 @@ internal class RecipeServiceImpl @Inject constructor(
                 transaction.update(documentRefer, "viewCount", newRecipeViewCount)
             }.await()
         }
-    
+
     override suspend fun deleteRecipe(recipe: Recipe): Unit =
-        withContext(Dispatchers.IO){
+        withContext(Dispatchers.IO) {
             firestore.collection(RECIPE_COLLECTION_ID)
                 .document(recipe.recipeId)
                 .delete()
                 .await()
         }
-    
+
+    override suspend fun fetchRecipe(recipeID: String): Recipe =
+        suspendCancellableCoroutine {
+            firestore.collection(RECIPE_COLLECTION_ID)
+                .document(recipeID)
+                .get()
+                .addOnSuccessListener { recipeFireStore ->
+                    if (recipeFireStore.metadata.isFromCache) {
+                        it.resumeWithException(NetworkException())
+                    } else {
+                        val recipe = recipeFireStore.toObject<RecipeDto>()?.toDomain()
+                        recipe?.let { item ->
+                            it.resumeWith(Result.success(item))
+                        } ?: it.resumeWithException(ApiException())
+                    }
+                }
+                .addOnFailureListener { exception ->
+                    it.resumeWithException(ApiException(exception.message))
+                }
+        }
+
     companion object {
-        
+
         const val RECIPE_COLLECTION_ID = "recipe"
     }
 }

--- a/remote/src/main/java/com/kdjj/remote/dao/RemoteRecipeService.kt
+++ b/remote/src/main/java/com/kdjj/remote/dao/RemoteRecipeService.kt
@@ -15,4 +15,8 @@ internal interface RemoteRecipeService {
     suspend fun deleteRecipe(
         recipe: Recipe
     )
+
+    suspend fun fetchRecipe(
+        recipeID: String
+    ): Recipe
 }

--- a/remote/src/main/java/com/kdjj/remote/datasource/RecipeRemoteDataSourceImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/datasource/RecipeRemoteDataSourceImpl.kt
@@ -30,4 +30,11 @@ internal class RecipeRemoteDataSourceImpl @Inject constructor(
         }.errorMap {
             Exception(it.message)
         }
+
+    override suspend fun fetchRecipe(recipeID: String): Result<Recipe> =
+        runCatching {
+            recipeService.fetchRecipe(recipeID)
+        }.errorMap {
+            Exception(it.message)
+        }
 }

--- a/remote/src/main/java/com/kdjj/remote/datasource/RecipeRemoteDataSourceImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/datasource/RecipeRemoteDataSourceImpl.kt
@@ -34,7 +34,5 @@ internal class RecipeRemoteDataSourceImpl @Inject constructor(
     override suspend fun fetchRecipe(recipeID: String): Result<Recipe> =
         runCatching {
             recipeService.fetchRecipe(recipeID)
-        }.errorMap {
-            Exception(it.message)
         }
 }


### PR DESCRIPTION
## 개요
레시피 개요 화면에서 필요한 Firebase에서 Recipe 정보 불러오기 기능과 불러온 Recipe정보를 로컬에 저장하는 훔쳐오기 기능을 구현

## 하고자 했던 것
- [x] FireStore에서 recipeID 값으로 Recipe정보 불러오기 구현 (UseCase, Repository, DataSource, RecipeService)
- [x] FireStore에서 불러온 Recipe정보 Local 저장소에 저장 구현 (SaveLocalRecipeUseCase)

## 변경 사항
SaveLocalUseCase에서 External Storage에 대한 image path만 처리하였는데 Remote에 대한 image path도 처리할수 있도록 수정

## 발생한 이슈
없음