### PR TITLE
[develop] UploadRecipeUseCase 수정

### DIFF
--- a/domain/src/main/java/com/kdjj/domain/usecase/UploadRecipeUseCase.kt
+++ b/domain/src/main/java/com/kdjj/domain/usecase/UploadRecipeUseCase.kt
@@ -1,14 +1,47 @@
 package com.kdjj.domain.usecase
 
+import com.kdjj.domain.model.RecipeState
 import com.kdjj.domain.repository.RecipeRepository
 import com.kdjj.domain.model.request.UploadRecipeRequest
+import com.kdjj.domain.repository.RecipeImageRepository
 import javax.inject.Inject
 
 class UploadRecipeUseCase @Inject constructor(
-    private val recipeRepository: RecipeRepository
+    private val recipeRepository: RecipeRepository,
+    private val recipeImageRepository: RecipeImageRepository
 ) : UseCase<UploadRecipeRequest, Unit> {
-    
-    override suspend fun invoke(request: UploadRecipeRequest): Result<Unit> {
-        return recipeRepository.uploadRecipe(request.recipe)
-    }
+
+    override suspend fun invoke(request: UploadRecipeRequest): Result<Unit> =
+        runCatching {
+            val recipe = request.recipe
+            val recipeImageUri = when (recipe.imgPath.isNotEmpty()) {
+                true -> {
+                    recipeImageRepository.convertInternalUriToRemoteStorageUri(recipe.imgPath)
+                        .getOrThrow()
+                }
+                false -> ""
+            }
+            val recipeStepList = recipe.stepList.map { step ->
+                val stepImageUri = when (step.imgPath.isNotEmpty()) {
+                    true -> {
+                        recipeImageRepository.convertInternalUriToRemoteStorageUri(step.imgPath)
+                            .getOrThrow()
+                    }
+                    false -> ""
+                }
+                step.copy(imgPath = stepImageUri)
+            }
+            recipeRepository.uploadRecipe(
+                recipe.copy(
+                    imgPath = recipeImageUri,
+                    stepList = recipeStepList,
+                )
+            ).getOrThrow()
+
+            recipeRepository.updateLocalRecipe(
+                recipe.copy(
+                    state = RecipeState.UPLOAD
+                )
+            ).getOrThrow()
+        }
 }


### PR DESCRIPTION
## 개요
로컬에 저장된 레시피 업로드 할때 이미지를 FireStorage에서 저장한 후 imagePath를 받아 Recipe객체에 저장 후 업로드 하도록 수정 

## 하고자 했던 것
- [x] 로컬에 저장된 레시피 업로드 할때 이미지를 FireStorage에서 저장하는 기능 추가

## 변경 사항
없음

## 발생한 이슈
없음