### PR TITLE
[develop]

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "com.kdjj.ratatouille"
         minSdk 23
         targetSdk 31
-        versionCode 2
-        versionName "1.1"
+        versionCode 3
+        versionName "2.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/domain/src/main/java/com/kdjj/domain/usecase/SaveLocalRecipeUseCase.kt
+++ b/domain/src/main/java/com/kdjj/domain/usecase/SaveLocalRecipeUseCase.kt
@@ -44,7 +44,8 @@ internal class SaveLocalRecipeUseCase @Inject constructor(
             recipeRepository.saveLocalRecipe(
                 recipe.copy(
                     imgPath = recipeImageUri,
-                    stepList = recipeStepList
+                    stepList = recipeStepList,
+                    createTime = System.currentTimeMillis()
                 )
             ).getOrThrow()
         }

--- a/domain/src/main/java/com/kdjj/domain/usecase/UploadRecipeUseCase.kt
+++ b/domain/src/main/java/com/kdjj/domain/usecase/UploadRecipeUseCase.kt
@@ -35,6 +35,7 @@ class UploadRecipeUseCase @Inject constructor(
                 recipe.copy(
                     imgPath = recipeImageUri,
                     stepList = recipeStepList,
+                    createTime = System.currentTimeMillis()
                 )
             ).getOrThrow()
 

--- a/local/src/main/java/com/kdjj/local/FileSaveHelper.kt
+++ b/local/src/main/java/com/kdjj/local/FileSaveHelper.kt
@@ -26,14 +26,15 @@ class FileSaveHelper @Inject constructor(
 
     suspend fun convertToByteArray(uri: String): Result<Pair<ByteArray, Float?>> = withContext(Dispatchers.IO) {
         runCatching {
-            val inputStream = contentResolver.openInputStream(Uri.parse(uri))
+            val changedUri = if (!uri.contains("://")) "file://${uri}" else uri
+            val inputStream = contentResolver.openInputStream(Uri.parse(changedUri))
             val byteArray = inputStream?.readBytes() ?: throw Exception()
 
-            val exifInputStream = contentResolver.openInputStream(Uri.parse(uri))
+            val exifInputStream = contentResolver.openInputStream(Uri.parse(changedUri))
             val oldExif = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                 ExifInterface(exifInputStream ?: throw Exception())
             } else {
-                ExifInterface(uri)
+                ExifInterface(changedUri)
             }
             val degree = when (oldExif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)) {
                 ExifInterface.ORIENTATION_ROTATE_90 -> 90f

--- a/local/src/main/java/com/kdjj/local/FileSaveHelper.kt
+++ b/local/src/main/java/com/kdjj/local/FileSaveHelper.kt
@@ -42,8 +42,6 @@ class FileSaveHelper @Inject constructor(
                 else -> null
             }
             byteArray to degree
-        }.errorMap {
-            Exception(it.message)
         }
     }
 
@@ -59,8 +57,6 @@ class FileSaveHelper @Inject constructor(
             val bitmap = convertByteArrayToBitmap(byteArray, degree)
             bitmap.compress(Bitmap.CompressFormat.PNG, 100, fos)
             filePath
-        }.errorMap {
-            Exception(it.message)
         }
     }
 

--- a/presentation/src/main/java/com/kdjj/presentation/view/adapter/MyRecipeListAdapter.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/adapter/MyRecipeListAdapter.kt
@@ -31,7 +31,11 @@ internal class MyRecipeListAdapter(private val viewModel: MyRecipeViewModel) :
         override fun areContentsTheSame(oldItem: MyRecipeItem, newItem: MyRecipeItem): Boolean {
             return when {
                 oldItem is MyRecipeItem.MyRecipe && newItem is MyRecipeItem.MyRecipe -> {
-                    oldItem.recipe.recipeId == newItem.recipe.recipeId
+                    oldItem.recipe.recipeId == newItem.recipe.recipeId &&
+                            oldItem.recipe.title == newItem.recipe.title &&
+                            oldItem.recipe.stepList == newItem.recipe.stepList &&
+                            oldItem.recipe.stuff == newItem.recipe.stuff &&
+                            oldItem.recipe.imgPath == newItem.recipe.imgPath
                 }
                 oldItem is MyRecipeItem.PlusButton && newItem is MyRecipeItem.PlusButton -> true
                 else -> false

--- a/presentation/src/main/java/com/kdjj/presentation/view/recipedetail/RecipeDetailActivity.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/recipedetail/RecipeDetailActivity.kt
@@ -20,6 +20,8 @@ import com.kdjj.presentation.databinding.ActivityRecipeDetailBinding
 import com.kdjj.presentation.view.adapter.RecipeDetailStepListAdapter
 import com.kdjj.presentation.view.adapter.RecipeDetailTimerListAdapter
 import com.kdjj.presentation.view.adapter.RecipeEditorListAdapter
+import com.kdjj.presentation.view.dialog.ConfirmDialogBuilder
+import com.kdjj.presentation.view.dialog.CustomProgressDialog
 import com.kdjj.presentation.viewmodel.recipedetail.RecipeDetailViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -29,6 +31,8 @@ class RecipeDetailActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityRecipeDetailBinding
     private val viewModel: RecipeDetailViewModel by viewModels()
+
+    private lateinit var loadingDialog: CustomProgressDialog
 
     private lateinit var stepListAdapter: RecipeDetailStepListAdapter
     private lateinit var timerListAdapter: RecipeDetailTimerListAdapter
@@ -61,6 +65,8 @@ class RecipeDetailActivity : AppCompatActivity() {
         binding = DataBindingUtil.setContentView(this, R.layout.activity_recipe_detail)
         binding.lifecycleOwner = this
         binding.viewModel = viewModel
+
+        loadingDialog = CustomProgressDialog(this)
 
         stepListAdapter = RecipeDetailStepListAdapter(viewModel)
         binding.recyclerViewDetailStep.adapter = stepListAdapter
@@ -116,6 +122,24 @@ class RecipeDetailActivity : AppCompatActivity() {
                     onAnimationEnd()
                 }
                 start()
+            }
+        })
+
+        viewModel.liveLoading.observe(this) { doLoading ->
+            if (doLoading) {
+                loadingDialog.show()
+            } else {
+                loadingDialog.dismiss()
+            }
+        }
+
+        viewModel.eventError.observe(this, EventObserver {
+            ConfirmDialogBuilder.create(
+                this,
+                "오류 발생",
+                "레시피를 들고오던 라따뚜이가 넘어졌습니다..ㅠㅠ\n확인버튼을 누르면 이전 화면으로 돌아갑니다."
+            ) {
+                finish()
             }
         })
     }

--- a/presentation/src/main/java/com/kdjj/presentation/view/recipedetail/RecipeDetailActivity.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/recipedetail/RecipeDetailActivity.kt
@@ -14,6 +14,8 @@ import com.kdjj.domain.model.*
 import com.kdjj.presentation.R
 import com.kdjj.presentation.common.DisplayConverter
 import com.kdjj.presentation.common.EventObserver
+import com.kdjj.presentation.common.RECIPE_ID
+import com.kdjj.presentation.common.RECIPE_STATE
 import com.kdjj.presentation.databinding.ActivityRecipeDetailBinding
 import com.kdjj.presentation.view.adapter.RecipeDetailStepListAdapter
 import com.kdjj.presentation.view.adapter.RecipeDetailTimerListAdapter
@@ -67,31 +69,20 @@ class RecipeDetailActivity : AppCompatActivity() {
         binding.recyclerViewDetailTimer.adapter = timerListAdapter
         ItemTouchHelper(itemTouchCallback).attachToRecyclerView(binding.recyclerViewDetailTimer)
 
-        val recipe = Recipe(
-            "",
-            "레시피 제목",
-            RecipeType(1, "기타"),
-            "",
-            "",
-            listOf(
-                RecipeStep("", "단계1", RecipeStepType.PREPARE, "1단계입니다.", "", 0),
-                RecipeStep("", "단계2", RecipeStepType.COOK, "2단계입니다. 약 20초 걸립니다.", "", 20),
-                RecipeStep("", "단계3", RecipeStepType.COOK, "3단계입니다. 약 2분 30초 걸립니다.", "", 150),
-                RecipeStep("", "단계4", RecipeStepType.COOK, "4단계입니다. 약 10초 걸립니다.", "", 10),
-            ),
-            "",
-            0,
-            false,
-            0,
-            RecipeState.CREATE
-        )
-
         setSupportActionBar(binding.toolbarDetail)
-        title = recipe.title
+        // TODO(set title)
+        //        title = recipe.title
 
         setObservers()
 
-        viewModel.initializeWith(recipe)
+        loadRecipe()
+    }
+
+    private fun loadRecipe() {
+        val (recipeId, recipeState) = intent.extras?.let { bundle ->
+            bundle.getString(RECIPE_ID) to (bundle.getSerializable(RECIPE_STATE) as? RecipeState)
+        } ?: null to null
+        viewModel.initializeWith(recipeId, recipeState)
     }
 
     private fun setObservers() {

--- a/presentation/src/main/java/com/kdjj/presentation/view/recipedetail/RecipeDetailActivity.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/recipedetail/RecipeDetailActivity.kt
@@ -76,11 +76,8 @@ class RecipeDetailActivity : AppCompatActivity() {
         ItemTouchHelper(itemTouchCallback).attachToRecyclerView(binding.recyclerViewDetailTimer)
 
         setSupportActionBar(binding.toolbarDetail)
-        // TODO(set title)
-        //        title = recipe.title
 
         setObservers()
-
         loadRecipe()
     }
 
@@ -142,5 +139,9 @@ class RecipeDetailActivity : AppCompatActivity() {
                 finish()
             }
         })
+
+        viewModel.liveTitle.observe(this) {
+            title = it
+        }
     }
 }

--- a/presentation/src/main/java/com/kdjj/presentation/view/recipeeditor/RecipeEditorActivity.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/recipeeditor/RecipeEditorActivity.kt
@@ -14,7 +14,10 @@ import androidx.core.view.size
 import androidx.databinding.DataBindingUtil
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.RecyclerView
+import com.kdjj.domain.model.RecipeState
 import com.kdjj.presentation.R
+import com.kdjj.presentation.common.RECIPE_ID
+import com.kdjj.presentation.common.RECIPE_STATE
 import com.kdjj.presentation.databinding.ActivityRecipeEditorBinding
 import com.kdjj.presentation.model.RecipeEditorItem
 import com.kdjj.presentation.view.adapter.RecipeEditorListAdapter
@@ -114,7 +117,12 @@ class RecipeEditorActivity : AppCompatActivity() {
 
         setupObservers()
 
-        viewModel.initializeWith(null)
+        loadRecipe()
+    }
+
+    private fun loadRecipe() {
+        val recipeId = intent.extras?.getString(RECIPE_ID)
+        viewModel.initializeWith(recipeId)
     }
 
     private fun setupObservers() {
@@ -158,15 +166,9 @@ class RecipeEditorActivity : AppCompatActivity() {
             .setTitle(R.string.selectPhoto)
             .setItems(R.array.photoSourceSelection) { _, i ->
                 when (i) {
-                    0 -> {
-                        startCamera()
-                    }
-                    1 -> {
-                        startGallery()
-                    }
-                    2 -> {
-                        viewModel.setImageEmpty()
-                    }
+                    0 -> startCamera()
+                    1 -> startGallery()
+                    2 -> viewModel.setImageEmpty()
                 }
             }
             .setOnCancelListener {

--- a/presentation/src/main/java/com/kdjj/presentation/view/recipeeditor/RecipeEditorActivity.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/recipeeditor/RecipeEditorActivity.kt
@@ -10,16 +10,12 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.FileProvider
-import androidx.core.view.size
 import androidx.databinding.DataBindingUtil
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.RecyclerView
-import com.kdjj.domain.model.RecipeState
 import com.kdjj.presentation.R
 import com.kdjj.presentation.common.RECIPE_ID
-import com.kdjj.presentation.common.RECIPE_STATE
 import com.kdjj.presentation.databinding.ActivityRecipeEditorBinding
-import com.kdjj.presentation.model.RecipeEditorItem
 import com.kdjj.presentation.view.adapter.RecipeEditorListAdapter
 import com.kdjj.presentation.view.dialog.ConfirmDialogBuilder
 import com.kdjj.presentation.view.dialog.CustomProgressDialog

--- a/presentation/src/main/java/com/kdjj/presentation/view/recipeeditor/RecipeEditorActivity.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/recipeeditor/RecipeEditorActivity.kt
@@ -14,6 +14,7 @@ import androidx.databinding.DataBindingUtil
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.RecyclerView
 import com.kdjj.presentation.R
+import com.kdjj.presentation.common.EventObserver
 import com.kdjj.presentation.common.RECIPE_ID
 import com.kdjj.presentation.databinding.ActivityRecipeEditorBinding
 import com.kdjj.presentation.view.adapter.RecipeEditorListAdapter
@@ -155,6 +156,16 @@ class RecipeEditorActivity : AppCompatActivity() {
                 loadingDialog.dismiss()
             }
         }
+
+        viewModel.eventError.observe(this, EventObserver {
+            ConfirmDialogBuilder.create(
+                this,
+                "오류 발생",
+                "레시피를 들고오던 라따뚜이가 넘어졌습니다..ㅠㅠ\n확인버튼을 누르면 이전 화면으로 돌아갑니다."
+            ) {
+                finish()
+            }
+        })
     }
 
     private fun showSelectImageDialog() {

--- a/presentation/src/main/java/com/kdjj/presentation/view/recipeeditor/RecipeEditorActivity.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/recipeeditor/RecipeEditorActivity.kt
@@ -127,9 +127,7 @@ class RecipeEditorActivity : AppCompatActivity() {
             model?.let { showSelectImageDialog() }
         }
 
-        viewModel.liveSaveResult.observe(this) { isSuccess ->
-            isSuccess ?: return@observe
-            viewModel.resetResultState()
+        viewModel.eventSaveResult.observe(this, EventObserver { isSuccess ->
             if (isSuccess) {
                 ConfirmDialogBuilder.create(
                     this,
@@ -143,11 +141,9 @@ class RecipeEditorActivity : AppCompatActivity() {
                     this,
                     "저장 실패",
                     "레시피를 저장하지 못했습니다.",
-                ) {
-
-                }
+                ) { }
             }
-        }
+        })
 
         viewModel.liveLoading.observe(this) { doLoading ->
             if (doLoading) {

--- a/presentation/src/main/java/com/kdjj/presentation/view/recipesummary/RecipeSummaryActivity.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/recipesummary/RecipeSummaryActivity.kt
@@ -16,6 +16,7 @@ import com.kdjj.presentation.common.RECIPE_STATE
 import com.kdjj.presentation.databinding.ActivityRecipeSummaryBinding
 import com.kdjj.presentation.model.RecipeSummaryType
 import com.kdjj.presentation.view.dialog.ConfirmDialogBuilder
+import com.kdjj.presentation.view.dialog.CustomProgressDialog
 import com.kdjj.presentation.view.recipedetail.RecipeDetailActivity
 import com.kdjj.presentation.view.recipeeditor.RecipeEditorActivity
 import com.kdjj.presentation.viewmodel.recipesummary.RecipeSummaryViewModel
@@ -51,6 +52,8 @@ class RecipeSummaryActivity : AppCompatActivity() {
             acc + list
         }.distinct()
     private var isFloatingActionButtonOpen = false
+
+    private lateinit var loadingDialog: CustomProgressDialog
     
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -58,6 +61,8 @@ class RecipeSummaryActivity : AppCompatActivity() {
         binding = DataBindingUtil.setContentView(this, R.layout.activity_recipe_summary)
         binding.viewModel = recipeSummaryViewModel
         binding.lifecycleOwner = this
+
+        loadingDialog = CustomProgressDialog(this)
         
         setSupportActionBar(binding.toolbarSummary)
         
@@ -137,6 +142,14 @@ class RecipeSummaryActivity : AppCompatActivity() {
             val message = if (isSuccess) "즐겨찾기 추가 / 제거 성공" else "즐겨찾기 추가 / 제거 실패"
             showSnackBar(message)
         })
+
+        liveLoading.observe(this@RecipeSummaryActivity) { doLoading ->
+            if (doLoading) {
+                loadingDialog.show()
+            } else {
+                loadingDialog.dismiss()
+            }
+        }
     }
     
     private fun initFloatingMenuVisibility(buttonList: List<AppCompatButton>?) = with(binding) {

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipedetail/RecipeDetailViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipedetail/RecipeDetailViewModel.kt
@@ -52,16 +52,23 @@ class RecipeDetailViewModel @Inject constructor(
     private var _liveFinishedTimerPosition = MutableLiveData<Int>()
     val liveFinishedTimerPosition: LiveData<Int> get () = _liveFinishedTimerPosition
 
+    private val _liveLoading = MutableLiveData(false)
+    val liveLoading: LiveData<Boolean> get() = _liveLoading
+
+    private val _eventError = MutableLiveData<Event<Unit>>()
+    val eventError: LiveData<Event<Unit>> get() = _eventError
+
     private var isInitialized = false
 
     fun initializeWith(recipeId: String?, state: RecipeState?) {
         if (isInitialized) return
 
         if (recipeId == null || state == null) {
-            // TODO(raise error)
+            _eventError.value = Event(Unit)
             return
         }
 
+        _liveLoading.value = true
         viewModelScope.launch {
             when (state) {
                 RecipeState.NETWORK -> {
@@ -71,7 +78,7 @@ class RecipeDetailViewModel @Inject constructor(
                             selectStep(recipe.stepList[0])
                         }
                         .onFailure {
-                            // TODO(raise error)
+                            _eventError.value = Event(Unit)
                         }
                 }
                 RecipeState.CREATE, RecipeState.DOWNLOAD, RecipeState.UPLOAD -> {
@@ -82,10 +89,11 @@ class RecipeDetailViewModel @Inject constructor(
                             selectStep(recipe.stepList[0])
                         }
                         .onFailure {
-                            // TODO(raise error)
+                            _eventError.value = Event(Unit)
                         }
                 }
             }
+            _liveLoading.value = false
         }
 
         isInitialized = true

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipedetail/RecipeDetailViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipedetail/RecipeDetailViewModel.kt
@@ -50,7 +50,7 @@ class RecipeDetailViewModel @Inject constructor(
     val eventCloseTimer: LiveData<Event<() -> Unit>> get() = _eventCloseTimer
 
     private var _liveFinishedTimerPosition = MutableLiveData<Int>()
-    val liveFinishedTimerPosition: LiveData<Int> get () = _liveFinishedTimerPosition
+    val liveFinishedTimerPosition: LiveData<Int> get() = _liveFinishedTimerPosition
 
     private val _liveLoading = MutableLiveData(false)
     val liveLoading: LiveData<Boolean> get() = _liveLoading

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipedetail/RecipeDetailViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipedetail/RecipeDetailViewModel.kt
@@ -58,6 +58,9 @@ class RecipeDetailViewModel @Inject constructor(
     private val _eventError = MutableLiveData<Event<Unit>>()
     val eventError: LiveData<Event<Unit>> get() = _eventError
 
+    private val _liveTitle = MutableLiveData<String>()
+    val liveTitle: LiveData<String> get() = _liveTitle
+
     private var isInitialized = false
 
     fun initializeWith(recipeId: String?, state: RecipeState?) {
@@ -76,6 +79,7 @@ class RecipeDetailViewModel @Inject constructor(
                         .onSuccess { recipe ->
                             _liveStepList.value = recipe.stepList
                             selectStep(recipe.stepList[0])
+                            _liveTitle.value = recipe.title
                         }
                         .onFailure {
                             _eventError.value = Event(Unit)
@@ -87,6 +91,7 @@ class RecipeDetailViewModel @Inject constructor(
                             val recipe = it.first()
                             _liveStepList.value = recipe.stepList
                             selectStep(recipe.stepList[0])
+                            _liveTitle.value = recipe.title
                         }
                         .onFailure {
                             _eventError.value = Event(Unit)

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipeeditor/RecipeEditorViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipeeditor/RecipeEditorViewModel.kt
@@ -55,8 +55,8 @@ internal class RecipeEditorViewModel @Inject constructor(
     private val _liveRegisterHasPressed = MutableLiveData(false)
     val liveRegisterHasPressed: LiveData<Boolean> get() = _liveRegisterHasPressed
 
-    private val _liveSaveResult = MutableLiveData<Boolean?>()
-    val liveSaveResult: LiveData<Boolean?> get() = _liveSaveResult
+    private val _eventSaveResult = MutableLiveData<Event<Boolean>>()
+    val eventSaveResult: LiveData<Event<Boolean>> get() = _eventSaveResult
 
     private val _liveLoading = MutableLiveData(false)
     val liveLoading: LiveData<Boolean> get() = _liveLoading
@@ -180,24 +180,20 @@ internal class RecipeEditorViewModel @Inject constructor(
                         if (isEditing) {
                             updateRemoteRecipeUseCase(UpdateRemoteRecipeRequest(recipe))
                                 .onSuccess {
-                                    _liveSaveResult.value = true
+                                    _eventSaveResult.value = Event(true)
                                 }
                                 .onFailure {
-                                    _liveSaveResult.value = false
+                                    _eventSaveResult.value = Event(false)
                                 }
                         } else {
-                            _liveSaveResult.value = true
+                            _eventSaveResult.value = Event(true)
                         }
                     }.onFailure {
                         it.printStackTrace()
-                        _liveSaveResult.value = false
+                        _eventSaveResult.value = Event(false)
                     }
             }
         }
-    }
-    
-    fun resetResultState() {
-        _liveSaveResult.value = null
     }
     
     private fun isRecipeValid(): Boolean {

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipeeditor/RecipeEditorViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipeeditor/RecipeEditorViewModel.kt
@@ -91,11 +91,11 @@ internal class RecipeEditorViewModel @Inject constructor(
                         )
                     }
                     notifyStepListChange()
-                    _liveLoading.value = false
                 }
                 .onFailure {
                     // TODO(raise error)
                 }
+                _liveLoading.value = false
         }
         isInitialized = true
     }

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipeeditor/RecipeEditorViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipeeditor/RecipeEditorViewModel.kt
@@ -13,6 +13,7 @@ import com.kdjj.domain.model.request.SaveLocalRecipeRequest
 import com.kdjj.domain.model.request.UpdateRemoteRecipeRequest
 import com.kdjj.domain.usecase.UpdateRemoteRecipeUseCase
 import com.kdjj.domain.usecase.UseCase
+import com.kdjj.presentation.common.Event
 import com.kdjj.presentation.common.IdGenerator
 import com.kdjj.presentation.common.RecipeStepValidator
 import com.kdjj.presentation.common.RecipeValidator
@@ -40,24 +41,35 @@ internal class RecipeEditorViewModel @Inject constructor(
     
     private lateinit var recipeMetaModel: RecipeEditorItem.RecipeMetaModel
     private var recipeStepModelList = listOf<RecipeEditorItem.RecipeStepModel>()
+
     private val _liveRecipeItemList = MutableLiveData<List<RecipeEditorItem>>()
     val liveRecipeItemList: LiveData<List<RecipeEditorItem>> get() = _liveRecipeItemList
+
     val stepTypes = RecipeStepType.values()
     private val _liveRecipeTypes = MutableLiveData<List<RecipeType>>()
     val liveRecipeTypes: LiveData<List<RecipeType>> get() = _liveRecipeTypes
+
     private val _liveImgTarget = MutableLiveData<RecipeEditorItem?>()
     val liveImgTarget: LiveData<RecipeEditorItem?> get() = _liveImgTarget
+
     private val _liveRegisterHasPressed = MutableLiveData(false)
     val liveRegisterHasPressed: LiveData<Boolean> get() = _liveRegisterHasPressed
+
     private val _liveSaveResult = MutableLiveData<Boolean?>()
     val liveSaveResult: LiveData<Boolean?> get() = _liveSaveResult
+
     private val _liveLoading = MutableLiveData(false)
     val liveLoading: LiveData<Boolean> get() = _liveLoading
+
     private var isInitialized = false
+
     private val _liveMoveToPosition = MutableLiveData<Int>()
     val liveMoveToPosition: LiveData<Int> get() = _liveMoveToPosition
 
     private var isEditing = false
+
+    private val _eventError = MutableLiveData<Event<Unit>>()
+    val eventError: LiveData<Event<Unit>> get() = _eventError
     
     fun initializeWith(recipeId: String?) {
         if (isInitialized) return
@@ -78,7 +90,7 @@ internal class RecipeEditorViewModel @Inject constructor(
                                 isEditing = true
                             }
                             .onFailure {
-                                // TODO(raise error)
+                                _eventError.value = Event(Unit)
                             }
                     } ?: run {
                         recipeMetaModel = RecipeEditorItem.RecipeMetaModel.create(
@@ -93,7 +105,7 @@ internal class RecipeEditorViewModel @Inject constructor(
                     notifyStepListChange()
                 }
                 .onFailure {
-                    // TODO(raise error)
+                    _eventError.value = Event(Unit)
                 }
                 _liveLoading.value = false
         }

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipesummary/RecipeSummaryViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipesummary/RecipeSummaryViewModel.kt
@@ -24,6 +24,7 @@ class RecipeSummaryViewModel @Inject constructor(
     private val fetchRemoteRecipeUseCase: UseCase<FetchRemoteRecipeRequest, Recipe>,
     private val saveLocalRecipeUseCase: UseCase<SaveLocalRecipeRequest, Boolean>,
     private val uploadRecipeUseCase: UseCase<UploadRecipeRequest, Unit>,
+    private val increaseViewCountUseCase: UseCase<IncreaseRemoteRecipeViewCountRequest, Unit>,
     private val idGenerator: IdGenerator
 ) : ViewModel() {
     
@@ -105,6 +106,7 @@ class RecipeSummaryViewModel @Inject constructor(
                         fetchRemoteRecipeUseCase(FetchRemoteRecipeRequest(recipeId))
                             .onSuccess { recipe ->
                                 _liveRecipe.value = recipe
+                                increaseViewCountUseCase(IncreaseRemoteRecipeViewCountRequest(recipe))
                             }
                     }
                 }


### PR DESCRIPTION
close #126

## 개요

수정, 상세 화면에서 데이터 로드

## 변경 사항

- 수정, 상세 화면에서 Id로 데이터 받아오기
- 수정 화면에서 일회성 liveData -> Event로 변경

## 발생 이슈

- 레시피 다운로드 받을 때 이미지가 있으면 순차적으로 전송하여 시간이 오래 걸림
  - 비동기 처리 필요
- 레시피 수정할 때 저장 두 번 눌러야 함

## 추가기능 아이디어

- 이미지 입력할 때 주소만 입력해도 가능하도록