### PR TITLE
[develop] 4주차 배포 버전 오류 hotfix

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "com.kdjj.ratatouille"
         minSdk 23
         targetSdk 31
-        versionCode 3
-        versionName "2.0"
+        versionCode 4
+        versionName "2.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/presentation/src/main/java/com/kdjj/presentation/common/IdGenerator.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/common/IdGenerator.kt
@@ -8,8 +8,16 @@ import javax.inject.Singleton
 
 @Singleton
 class IdGenerator @Inject constructor(@ApplicationContext private val context: Context) {
+    private var lastGenerateTime: Long = 0L
 
-    fun generateId() = getDeviceId() + System.currentTimeMillis()
+    fun generateId(): String {
+        var currentTime = System.currentTimeMillis()
+        while (currentTime == lastGenerateTime) {
+            currentTime++
+        }
+        lastGenerateTime = currentTime
+        return getDeviceId() + currentTime
+    }
 
     fun getDeviceId(): String {
         return Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)

--- a/presentation/src/main/java/com/kdjj/presentation/model/RecipeListItemModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/model/RecipeListItemModel.kt
@@ -18,7 +18,7 @@ internal fun Recipe.toRecipeListItemModel() =
     RecipeListItemModel(
         recipeId,
         title,
-        stepList.map { it.seconds }.reduce { acc, i -> acc + i },
+        stepList.map { it.seconds }.fold(0) { acc, i -> acc + i },
         stuff,
         viewCount,
         imgPath,

--- a/presentation/src/main/java/com/kdjj/presentation/view/dialog/ConfirmDialogBuilder.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/dialog/ConfirmDialogBuilder.kt
@@ -17,6 +17,7 @@ internal object ConfirmDialogBuilder {
         val binding = DialogConfirmBinding.inflate(LayoutInflater.from(context))
         val dialog = AlertDialog.Builder(context)
             .setView(binding.root)
+            .setCancelable(false)
             .create()
         binding.model = ConfirmDialogModel(dialog, title, content, onConfirmListener)
         dialog.window?.setBackgroundDrawableResource(android.R.color.transparent)

--- a/presentation/src/main/java/com/kdjj/presentation/view/dialog/CustomProgressDialog.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/dialog/CustomProgressDialog.kt
@@ -11,6 +11,7 @@ class CustomProgressDialog(context: Context) : Dialog(context) {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.dialog_progress)
+        setCancelable(false)
         window?.setBackgroundDrawableResource(android.R.color.transparent)
     }
 }

--- a/presentation/src/main/java/com/kdjj/presentation/view/recipesummary/RecipeSummaryActivity.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/recipesummary/RecipeSummaryActivity.kt
@@ -48,7 +48,7 @@ class RecipeSummaryActivity : AppCompatActivity() {
         )
     )
     private val allFloatingButtonList = floatingMenuIdListMap.values
-        .reduce { acc, list ->
+        .fold(listOf<Int>()) { acc, list ->
             acc + list
         }.distinct()
     private var isFloatingActionButtonOpen = false

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipesummary/RecipeSummaryViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipesummary/RecipeSummaryViewModel.kt
@@ -157,7 +157,11 @@ class RecipeSummaryViewModel @Inject constructor(
         viewModelScope.launch {
             liveRecipe.value?.let { recipe ->
                 val newRecipeId = idGenerator.generateId()
-                val newRecipe = recipe.copy(recipeId = newRecipeId, state = RecipeState.DOWNLOAD)
+                val newRecipe = recipe.copy(
+                    recipeId = newRecipeId,
+                    state = RecipeState.DOWNLOAD,
+                    stepList = recipe.stepList.map { it.copy(stepId = idGenerator.generateId()) }
+                )
                 val saveResult = saveLocalRecipeUseCase(SaveLocalRecipeRequest(newRecipe))
 
                 _eventSaveFinish.value = Event(saveResult.isSuccess)
@@ -174,7 +178,8 @@ class RecipeSummaryViewModel @Inject constructor(
                 val newRecipe = recipe.copy(
                     recipeId = newRecipeId,
                     state = RecipeState.DOWNLOAD,
-                    isFavorite = true
+                    isFavorite = true,
+                    stepList = recipe.stepList.map { it.copy(stepId = idGenerator.generateId()) }
                 )
                 val saveResult = saveLocalRecipeUseCase(SaveLocalRecipeRequest(newRecipe))
 


### PR DESCRIPTION
close #130

## 하고자 했던 것

- 동일한 레시피를 여러 번 훔쳐오면 그 중 한 개만 정상 동작하는 오류 수정
- 로딩, 확인 화면 다른 곳 누르면 취소되는 문제 수정
- 레시피와 첫 번째 단계에 이미지 설정하면 저장이 이상하게 되는 오류 수정

## 변경사항

- 레시피와 단계의 ID가 동일하여 이미지 저장에 오류 발생
- 확인, 로딩창 취소할 수 없도록 수정
- reduce에서 혹시나 발생할 수 있는 문제, fold로 수정
- 훔쳐오기 할 때 단계 아이디 변경