### PR TITLE
[develop] viewholder recycle 될때 Glide clear 처리 

### DIFF
--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -74,7 +74,6 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$livedata_version"
 
     implementation 'com.github.bumptech.glide:glide:4.12.0'
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.12.0'
 
     implementation 'com.airbnb.android:lottie:4.2.1'
 

--- a/presentation/src/main/java/com/kdjj/presentation/view/adapter/MyRecipeListAdapter.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/adapter/MyRecipeListAdapter.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
 import com.kdjj.presentation.databinding.ItemMyRecipeAddRecipeBinding
 import com.kdjj.presentation.databinding.ItemMyRecipeBinding
 import com.kdjj.presentation.databinding.ItemMyRecipeProgressBinding
@@ -68,6 +69,10 @@ internal class MyRecipeListAdapter(private val viewModel: MyRecipeViewModel) :
         fun bind(item: MyRecipeItem.MyRecipe) {
             binding.myRecipeViewModel = viewModel
             binding.myRecipeItem = item
+        }
+
+        fun onViewRecycled() {
+            Glide.with(binding.root.context).clear(binding.imageViewMyRecipe)
         }
     }
 
@@ -130,6 +135,12 @@ internal class MyRecipeListAdapter(private val viewModel: MyRecipeViewModel) :
         ObjectAnimator.ofFloat(view, View.TRANSLATION_Y, 100f, 0f).apply {
             duration = 200
             start()
+        }
+    }
+
+    override fun onViewRecycled(holder: RecyclerView.ViewHolder) {
+        when (holder) {
+            is MyRecipeViewHolder -> holder.onViewRecycled()
         }
     }
 

--- a/presentation/src/main/java/com/kdjj/presentation/view/adapter/OthersRecipeListAdapter.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/adapter/OthersRecipeListAdapter.kt
@@ -2,7 +2,10 @@ package com.kdjj.presentation.view.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.recyclerview.widget.DiffUtil
+import com.bumptech.glide.Glide
+import com.kdjj.presentation.R
 import com.kdjj.presentation.databinding.ItemListRecipeBinding
 import com.kdjj.presentation.model.RecipeListItemModel
 import com.kdjj.presentation.viewmodel.others.OthersViewModel
@@ -24,13 +27,19 @@ class OthersRecipeListAdapter(
     }
 
     override fun bind(
-        holder: SingleViewTypeViewHolder<RecipeListItemModel, ItemListRecipeBinding>,
+        holder: SingleViewTypeViewHolder<ItemListRecipeBinding>,
         item: RecipeListItemModel,
     ) {
        with(holder.binding) {
            recipe = item
            executePendingBindings()
        }
+    }
+
+    override fun onViewRecycled(holder: SingleViewTypeViewHolder<ItemListRecipeBinding>) {
+        with(holder.binding) {
+            Glide.with(root.context).clear(imageViewOthersItemImg)
+        }
     }
 }
 

--- a/presentation/src/main/java/com/kdjj/presentation/view/adapter/RecipeDetailStepListAdapter.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/adapter/RecipeDetailStepListAdapter.kt
@@ -3,7 +3,6 @@ package com.kdjj.presentation.view.adapter
 import android.graphics.Paint
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import android.widget.TextView
 import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.recyclerview.widget.DiffUtil
 import com.kdjj.domain.model.RecipeStep
@@ -37,7 +36,7 @@ class RecipeDetailStepListAdapter(
     }
 
     override fun bind(
-        holder: SingleViewTypeViewHolder<RecipeStep, ItemDetailStepBinding>,
+        holder: SingleViewTypeViewHolder<ItemDetailStepBinding>,
         item: RecipeStep
     ) {
         holder.binding.step = item

--- a/presentation/src/main/java/com/kdjj/presentation/view/adapter/RecipeDetailTimerListAdapter.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/adapter/RecipeDetailTimerListAdapter.kt
@@ -32,7 +32,7 @@ class RecipeDetailTimerListAdapter(
             }
 
     override fun bind(
-        holder: SingleViewTypeViewHolder<StepTimerModel, ItemDetailTimerBinding>,
+        holder: SingleViewTypeViewHolder<ItemDetailTimerBinding>,
         item: StepTimerModel
     ) {
         with(holder.binding) {

--- a/presentation/src/main/java/com/kdjj/presentation/view/adapter/RecipeEditorListAdapter.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/adapter/RecipeEditorListAdapter.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
 import com.kdjj.presentation.R
 import com.kdjj.presentation.databinding.ItemEditorAddStepBinding
 import com.kdjj.presentation.databinding.ItemEditorRecipeMetaBinding
@@ -61,6 +62,10 @@ internal class RecipeEditorListAdapter(private val viewModel: RecipeEditorViewMo
             binding.model = item
             binding.executePendingBindings()
         }
+
+        fun onViewRecycled() {
+            Glide.with(binding.root.context).clear(binding.imageViewEditorRecipe)
+        }
     }
 
     class RecipeStepViewHolder(
@@ -81,6 +86,10 @@ internal class RecipeEditorListAdapter(private val viewModel: RecipeEditorViewMo
         fun bind(item: RecipeEditorItem.RecipeStepModel) {
             binding.model = item
             binding.executePendingBindings()
+        }
+
+        fun onViewRecycled() {
+            Glide.with(binding.root.context).clear(binding.imageViewEditorStep)
         }
     }
 
@@ -145,6 +154,13 @@ internal class RecipeEditorListAdapter(private val viewModel: RecipeEditorViewMo
         (item as? RecipeEditorItem.RecipeMetaModel)?.let { (holder as RecipeMetaViewHolder).bind(item) }
             ?: (item as? RecipeEditorItem.RecipeStepModel)?.let { (holder as RecipeStepViewHolder).bind(item) }
             ?: (item as? RecipeEditorItem.PlusButton)?.let { (holder as AddStepViewHolder).bind() }
+    }
+
+    override fun onViewRecycled(holder: RecyclerView.ViewHolder) {
+        when (holder) {
+            is RecipeStepViewHolder -> holder.onViewRecycled()
+            is RecipeMetaViewHolder -> holder.onViewRecycled()
+        }
     }
 
     companion object {

--- a/presentation/src/main/java/com/kdjj/presentation/view/adapter/SearchRecipeListAdapter.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/adapter/SearchRecipeListAdapter.kt
@@ -2,6 +2,7 @@ package com.kdjj.presentation.view.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import com.bumptech.glide.Glide
 import com.kdjj.presentation.databinding.ItemListRecipeBinding
 import com.kdjj.presentation.model.RecipeListItemModel
 import com.kdjj.presentation.viewmodel.search.SearchViewModel
@@ -23,12 +24,18 @@ class SearchRecipeListAdapter(
     }
 
     override fun bind(
-        holder: SingleViewTypeViewHolder<RecipeListItemModel, ItemListRecipeBinding>,
+        holder: SingleViewTypeViewHolder<ItemListRecipeBinding>,
         item: RecipeListItemModel,
     ) {
        with(holder.binding) {
            recipe = item
            executePendingBindings()
        }
+    }
+
+    override fun onViewRecycled(holder: SingleViewTypeViewHolder<ItemListRecipeBinding>) {
+        with(holder.binding) {
+            Glide.with(root.context).clear(imageViewOthersItemImg)
+        }
     }
 }

--- a/presentation/src/main/java/com/kdjj/presentation/view/adapter/SingleViewTypeListAdapter.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/adapter/SingleViewTypeListAdapter.kt
@@ -8,9 +8,9 @@ import androidx.recyclerview.widget.RecyclerView
 
 abstract class SingleViewTypeListAdapter<T, VDB : ViewDataBinding> constructor(
     diffUtil : DiffUtil.ItemCallback<T>,
-) : ListAdapter<T, SingleViewTypeViewHolder<T, VDB>>(diffUtil) {
+) : ListAdapter<T, SingleViewTypeViewHolder<VDB>>(diffUtil) {
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SingleViewTypeViewHolder<T, VDB> {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SingleViewTypeViewHolder<VDB> {
         val binding = createBinding(parent)
         return SingleViewTypeViewHolder(binding, { b, getItemPosition -> initViewHolder(b, getItemPosition)} )
     }
@@ -19,14 +19,14 @@ abstract class SingleViewTypeListAdapter<T, VDB : ViewDataBinding> constructor(
 
     protected open fun initViewHolder(binding: VDB, getItemPosition: () -> Int) {}
 
-    override fun onBindViewHolder(holder: SingleViewTypeViewHolder<T, VDB>, position: Int) {
+    override fun onBindViewHolder(holder: SingleViewTypeViewHolder<VDB>, position: Int) {
         bind(holder, getItem(position))
     }
 
-    protected abstract fun bind(holder: SingleViewTypeViewHolder<T, VDB>, item: T)
+    protected abstract fun bind(holder: SingleViewTypeViewHolder<VDB>, item: T)
 }
 
-class SingleViewTypeViewHolder<T, VDB : ViewDataBinding> constructor(
+class SingleViewTypeViewHolder<VDB : ViewDataBinding> constructor(
     val binding: VDB,
     onViewHolderInit: (VDB, getAdapterPosition: () -> Int) -> Unit,
 ) : RecyclerView.ViewHolder(binding.root) {


### PR DESCRIPTION
## 개요
Issue: https://github.com/boostcampwm-2021/Android08-Ratatouille/issues/143
## 하고자 했던 것
RecyclerView 에서 ViewHolder 가 recycle 될때, 
이미지뷰 Glide clear 처리 
## 변경 사항
09fd647538c85a98309969c9e85ea14ce9d1fc13
## 발생한 이슈
