### PR TITLE
[develop] fireStore paging 처리 snapshot 으로 수정, suspendcancellablecoroutine 제거 

### DIFF
--- a/remote/src/main/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImpl.kt
@@ -20,17 +20,7 @@ internal class RecipeListRemoteDataSourceImpl @Inject constructor(
         runCatching {
             recipeListService.fetchLatestRecipeListAfter(refresh)
         }.errorMap {
-            when (it) {
-                is FirebaseFirestoreException -> {
-                    when (it.code.value()) {
-                        14 -> NetworkException()
-                        else -> ApiException()
-                    }
-                }
-                else -> {
-                    Exception(it)
-                }
-            }
+            fireStoreExceptionToDomain(it)
         }
     
     override suspend fun fetchPopularRecipeListAfter(
@@ -38,6 +28,8 @@ internal class RecipeListRemoteDataSourceImpl @Inject constructor(
     ): Result<List<Recipe>> =
         runCatching {
             recipeListService.fetchPopularRecipeListAfter(refresh)
+        }.errorMap {
+            fireStoreExceptionToDomain(it)
         }
     
     override suspend fun fetchSearchRecipeListAfter(
@@ -46,5 +38,18 @@ internal class RecipeListRemoteDataSourceImpl @Inject constructor(
     ): Result<List<Recipe>> =
         runCatching {
             recipeListService.fetchSearchRecipeListAfter(keyword, refresh)
+        }
+
+    private fun fireStoreExceptionToDomain(throwable: Throwable) =
+        when (throwable) {
+            is FirebaseFirestoreException -> {
+                when (throwable.code.value()) {
+                    14 -> NetworkException()
+                    else -> ApiException()
+                }
+            }
+            else -> {
+                Exception(throwable)
+            }
         }
 }

--- a/remote/src/main/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImpl.kt
@@ -1,19 +1,36 @@
 package com.kdjj.remote.datasource
 
+import com.google.firebase.firestore.FirebaseFirestoreException
+import com.kdjj.data.common.errorMap
 import com.kdjj.data.datasource.RecipeListRemoteDataSource
 import com.kdjj.domain.model.Recipe
+import com.kdjj.domain.model.exception.ApiException
+import com.kdjj.domain.model.exception.NetworkException
 import com.kdjj.remote.dao.RemoteRecipeListService
+import java.lang.Exception
 import javax.inject.Inject
 
 internal class RecipeListRemoteDataSourceImpl @Inject constructor(
     private val recipeListService: RemoteRecipeListService,
 ) : RecipeListRemoteDataSource {
-    
+
     override suspend fun fetchLatestRecipeListAfter(
         refresh: Boolean
     ): Result<List<Recipe>> =
         runCatching {
             recipeListService.fetchLatestRecipeListAfter(refresh)
+        }.errorMap {
+            when (it) {
+                is FirebaseFirestoreException -> {
+                    when (it.code.value()) {
+                        14 -> NetworkException()
+                        else -> ApiException()
+                    }
+                }
+                else -> {
+                    Exception(it)
+                }
+            }
         }
     
     override suspend fun fetchPopularRecipeListAfter(

--- a/remote/src/main/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImpl.kt
@@ -38,6 +38,8 @@ internal class RecipeListRemoteDataSourceImpl @Inject constructor(
     ): Result<List<Recipe>> =
         runCatching {
             recipeListService.fetchSearchRecipeListAfter(keyword, refresh)
+        }.errorMap {
+            fireStoreExceptionToDomain(it)
         }
 
     private fun fireStoreExceptionToDomain(throwable: Throwable) =


### PR DESCRIPTION
## 개요
Issue: https://github.com/boostcampwm-2021/Android08-Ratatouille/issues/147
## 하고자 했던 것
fireStore paging 처리 snapshot 으로 수정 
## 변경 사항
기존에 field value 로 처리하던 paging 처리를 snapshot 으로 수정 

## 발생한 이슈
