### PR TITLE
[develop] fireStore paging 처리시, withContext 로 수정 

### DIFF
--- a/remote/src/main/java/com/kdjj/remote/dao/RecipeListServiceImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/dao/RecipeListServiceImpl.kt
@@ -34,16 +34,15 @@ internal class RecipeListServiceImpl @Inject constructor(
                 .orderBy(FIELD_CREATE_TIME, Query.Direction.DESCENDING)
                 .limit(PAGING_SIZE)
 
-            with(query.get(Source.SERVER).await()) {
-                if (documents.isNotEmpty()) {
-                    latestListQuery = fireStore.collection(RECIPE_COLLECTION_ID)
-                        .orderBy(FIELD_CREATE_TIME, Query.Direction.DESCENDING)
-                        .startAfter(documents.last())
-                        .limit(PAGING_SIZE)
-                }
-                map {
-                    it.toObject<RecipeDto>().toDomain()
-                }
+            val querySnapshot = query.get(Source.SERVER).await()
+            if (querySnapshot.documents.isNotEmpty()) {
+                latestListQuery = fireStore.collection(RECIPE_COLLECTION_ID)
+                    .orderBy(FIELD_CREATE_TIME, Query.Direction.DESCENDING)
+                    .startAfter(querySnapshot.documents.last())
+                    .limit(PAGING_SIZE)
+            }
+            querySnapshot.map {
+                it.toObject<RecipeDto>().toDomain()
             }
         }
 
@@ -59,16 +58,15 @@ internal class RecipeListServiceImpl @Inject constructor(
                 .orderBy(FIELD_VIEW_COUNT, Query.Direction.DESCENDING)
                 .limit(PAGING_SIZE)
 
-            with(query.get(Source.SERVER).await()) {
-                if (documents.isNotEmpty()) {
-                    popularListQuery = fireStore.collection(RECIPE_COLLECTION_ID)
-                        .orderBy(FIELD_VIEW_COUNT, Query.Direction.DESCENDING)
-                        .startAfter(documents.last())
-                        .limit(PAGING_SIZE)
-                }
-                map {
-                    it.toObject<RecipeDto>().toDomain()
-                }
+            val querySnapshot = query.get(Source.SERVER).await()
+            if (querySnapshot.documents.isNotEmpty()) {
+                popularListQuery = fireStore.collection(RECIPE_COLLECTION_ID)
+                    .orderBy(FIELD_VIEW_COUNT, Query.Direction.DESCENDING)
+                    .startAfter(querySnapshot.documents.last())
+                    .limit(PAGING_SIZE)
+            }
+            querySnapshot.map {
+                it.toObject<RecipeDto>().toDomain()
             }
         }
     
@@ -87,18 +85,17 @@ internal class RecipeListServiceImpl @Inject constructor(
                 .orderBy(FIELD_TITLE, Query.Direction.ASCENDING)
                 .limit(PAGING_SIZE)
 
-            with(query.get(Source.SERVER).await()) {
-                if (documents.isNotEmpty()) {
-                    searchListQuery = fireStore.collection(RECIPE_COLLECTION_ID)
-                        .whereGreaterThanOrEqualTo(FIELD_TITLE, keyword)
-                        .whereLessThan(FIELD_TITLE, keyword + HANGLE_MAX_VALUE)
-                        .orderBy(FIELD_TITLE, Query.Direction.ASCENDING)
-                        .startAfter(documents.last())
-                        .limit(PAGING_SIZE)
-                }
-                map {
-                    it.toObject<RecipeDto>().toDomain()
-                }
+            val querySnapshot = query.get(Source.SERVER).await()
+            if (querySnapshot.documents.isNotEmpty()) {
+                searchListQuery = fireStore.collection(RECIPE_COLLECTION_ID)
+                    .whereGreaterThanOrEqualTo(FIELD_TITLE, keyword)
+                    .whereLessThan(FIELD_TITLE, keyword + HANGLE_MAX_VALUE)
+                    .orderBy(FIELD_TITLE, Query.Direction.ASCENDING)
+                    .startAfter(querySnapshot.documents.last())
+                    .limit(PAGING_SIZE)
+            }
+            querySnapshot.map {
+                it.toObject<RecipeDto>().toDomain()
             }
         }
     

--- a/remote/src/main/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImpl.kt
@@ -20,17 +20,7 @@ internal class RecipeListRemoteDataSourceImpl @Inject constructor(
         runCatching {
             recipeListService.fetchLatestRecipeListAfter(refresh)
         }.errorMap {
-            when (it) {
-                is FirebaseFirestoreException -> {
-                    when (it.code.value()) {
-                        14 -> NetworkException()
-                        else -> ApiException()
-                    }
-                }
-                else -> {
-                    Exception(it)
-                }
-            }
+            fireStoreExceptionToDomain(it)
         }
     
     override suspend fun fetchPopularRecipeListAfter(
@@ -38,6 +28,8 @@ internal class RecipeListRemoteDataSourceImpl @Inject constructor(
     ): Result<List<Recipe>> =
         runCatching {
             recipeListService.fetchPopularRecipeListAfter(refresh)
+        }.errorMap {
+            fireStoreExceptionToDomain(it)
         }
     
     override suspend fun fetchSearchRecipeListAfter(
@@ -46,5 +38,18 @@ internal class RecipeListRemoteDataSourceImpl @Inject constructor(
     ): Result<List<Recipe>> =
         runCatching {
             recipeListService.fetchSearchRecipeListAfter(keyword, refresh)
+        }
+
+    private fun fireStoreExceptionToDomain(throwable: Throwable) =
+        when (throwable) {
+            is FirebaseFirestoreException -> {
+                when (throwable.code.value()) {
+                    14 -> NetworkException()
+                    else -> ApiException()
+                }
+            }
+            else -> {
+                Exception(throwable)
+            }
         }
 }

--- a/remote/src/main/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImpl.kt
@@ -1,19 +1,36 @@
 package com.kdjj.remote.datasource
 
+import com.google.firebase.firestore.FirebaseFirestoreException
+import com.kdjj.data.common.errorMap
 import com.kdjj.data.datasource.RecipeListRemoteDataSource
 import com.kdjj.domain.model.Recipe
+import com.kdjj.domain.model.exception.ApiException
+import com.kdjj.domain.model.exception.NetworkException
 import com.kdjj.remote.dao.RemoteRecipeListService
+import java.lang.Exception
 import javax.inject.Inject
 
 internal class RecipeListRemoteDataSourceImpl @Inject constructor(
     private val recipeListService: RemoteRecipeListService,
 ) : RecipeListRemoteDataSource {
-    
+
     override suspend fun fetchLatestRecipeListAfter(
         refresh: Boolean
     ): Result<List<Recipe>> =
         runCatching {
             recipeListService.fetchLatestRecipeListAfter(refresh)
+        }.errorMap {
+            when (it) {
+                is FirebaseFirestoreException -> {
+                    when (it.code.value()) {
+                        14 -> NetworkException()
+                        else -> ApiException()
+                    }
+                }
+                else -> {
+                    Exception(it)
+                }
+            }
         }
     
     override suspend fun fetchPopularRecipeListAfter(

--- a/remote/src/main/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImpl.kt
@@ -38,6 +38,8 @@ internal class RecipeListRemoteDataSourceImpl @Inject constructor(
     ): Result<List<Recipe>> =
         runCatching {
             recipeListService.fetchSearchRecipeListAfter(keyword, refresh)
+        }.errorMap {
+            fireStoreExceptionToDomain(it)
         }
 
     private fun fireStoreExceptionToDomain(throwable: Throwable) =


### PR DESCRIPTION
## 개요
Issue: https://github.com/boostcampwm-2021/Android08-Ratatouille/issues/147
## 하고자 했던 것
fireStore paging 처리시 spendCancellableCoroutine 제거하고 , 
withContext 사용하도록 수정 
```kotlin
query.get(Source.SERVER).await()
```
query.get 에서 SERVER 에서만 가져오도록 강제할 수 있어서 더 이상 spendCancellableCoroutine 사용이 불필요해졌습니다. 
spendCancellableCoroutine 제거하고 withContext 로 수정했습니다. 
관련 Discussions : https://github.com/boostcampwm-2021/Android08-Ratatouille/discussions/91
## 변경 사항
- [x] spendCancellableCoroutine 제거 4b0dbca9e55b21f21a3b1c9318e3f7aaee4310c2 f169becf60b3349a2bd2e77627a1862750a7ea37 d9516106bd71184297a9e4e82d464d858a39983f
## 발생한 이슈
