### PR TITLE
[develop] firestore recipe fetch 처리시 suspendCancellableCoroutine 제거

### DIFF
--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/my/MyRecipeViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/my/MyRecipeViewModel.kt
@@ -11,6 +11,7 @@ import com.kdjj.presentation.common.Event
 import com.kdjj.presentation.model.MyRecipeItem
 import com.kdjj.presentation.model.SortType
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
@@ -108,7 +109,9 @@ internal class MyRecipeViewModel @Inject constructor(
                     }
                 }
             }.onFailure {
-                _eventDataLoadFailed.value = Event(Unit)
+                if (!(it is CancellationException)) {
+                    _eventDataLoadFailed.value = Event(Unit)
+                }
             }
             isFetching = false
         }

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/my/MyRecipeViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/my/MyRecipeViewModel.kt
@@ -109,7 +109,7 @@ internal class MyRecipeViewModel @Inject constructor(
                     }
                 }
             }.onFailure {
-                if (!(it is CancellationException)) {
+                if (it !is CancellationException) {
                     _eventDataLoadFailed.value = Event(Unit)
                 }
             }

--- a/remote/src/main/java/com/kdjj/remote/common/Utils.kt
+++ b/remote/src/main/java/com/kdjj/remote/common/Utils.kt
@@ -1,0 +1,19 @@
+package com.kdjj.remote.common
+
+import com.google.firebase.firestore.FirebaseFirestoreException
+import com.kdjj.domain.model.exception.ApiException
+import com.kdjj.domain.model.exception.NetworkException
+import java.lang.Exception
+
+internal fun fireStoreExceptionToDomain(throwable: Throwable) =
+    when (throwable) {
+        is FirebaseFirestoreException -> {
+            when (throwable.code.value()) {
+                14 -> NetworkException()
+                else -> ApiException()
+            }
+        }
+        else -> {
+            Exception(throwable)
+        }
+    }

--- a/remote/src/main/java/com/kdjj/remote/dao/RecipeServiceImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/dao/RecipeServiceImpl.kt
@@ -1,6 +1,7 @@
 package com.kdjj.remote.dao
 
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Source
 import com.google.firebase.firestore.ktx.toObject
 import com.kdjj.domain.model.Recipe
 import com.kdjj.domain.model.exception.ApiException
@@ -51,7 +52,7 @@ internal class RecipeServiceImpl @Inject constructor(
         withContext(Dispatchers.IO) {
             val documentSnapShot = firestore.collection(RECIPE_COLLECTION_ID)
                 .document(recipeID)
-                .get()
+                .get(Source.SERVER)
                 .await()
             documentSnapShot.toObject<RecipeDto>()?.toDomain() ?: throw Exception()
         }

--- a/remote/src/main/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImpl.kt
@@ -1,13 +1,10 @@
 package com.kdjj.remote.datasource
 
-import com.google.firebase.firestore.FirebaseFirestoreException
 import com.kdjj.data.common.errorMap
 import com.kdjj.data.datasource.RecipeListRemoteDataSource
 import com.kdjj.domain.model.Recipe
-import com.kdjj.domain.model.exception.ApiException
-import com.kdjj.domain.model.exception.NetworkException
+import com.kdjj.remote.common.fireStoreExceptionToDomain
 import com.kdjj.remote.dao.RemoteRecipeListService
-import java.lang.Exception
 import javax.inject.Inject
 
 internal class RecipeListRemoteDataSourceImpl @Inject constructor(
@@ -40,18 +37,5 @@ internal class RecipeListRemoteDataSourceImpl @Inject constructor(
             recipeListService.fetchSearchRecipeListAfter(keyword, refresh)
         }.errorMap {
             fireStoreExceptionToDomain(it)
-        }
-
-    private fun fireStoreExceptionToDomain(throwable: Throwable) =
-        when (throwable) {
-            is FirebaseFirestoreException -> {
-                when (throwable.code.value()) {
-                    14 -> NetworkException()
-                    else -> ApiException()
-                }
-            }
-            else -> {
-                Exception(throwable)
-            }
         }
 }

--- a/remote/src/main/java/com/kdjj/remote/datasource/RecipeRemoteDataSourceImpl.kt
+++ b/remote/src/main/java/com/kdjj/remote/datasource/RecipeRemoteDataSourceImpl.kt
@@ -3,6 +3,7 @@ package com.kdjj.remote.datasource
 import com.kdjj.data.common.errorMap
 import com.kdjj.data.datasource.RecipeRemoteDataSource
 import com.kdjj.domain.model.Recipe
+import com.kdjj.remote.common.fireStoreExceptionToDomain
 import com.kdjj.remote.dao.RemoteRecipeService
 import javax.inject.Inject
 
@@ -34,5 +35,7 @@ internal class RecipeRemoteDataSourceImpl @Inject constructor(
     override suspend fun fetchRecipe(recipeID: String): Result<Recipe> =
         runCatching {
             recipeService.fetchRecipe(recipeID)
+        }.errorMap {
+            fireStoreExceptionToDomain(it)
         }
 }


### PR DESCRIPTION
## 개요
firestore에서 recipe 불러올때 suspendCancellableCoroutine 처리하지 않고 runcatching으로 에러 처리

## 하고자 했던 것
- [x] suspendCancellableCoroutine

## 변경 사항
fireStoreExceptionToDomain 함수 Common Package의 Utils 파일로 이동

## 발생한 이슈
없음
