### PR TITLE
fix: 개요 들어올 시 타입 업데이트 하는 기능 추가 close #135

### DIFF
--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipesummary/RecipeSummaryViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipesummary/RecipeSummaryViewModel.kt
@@ -3,6 +3,7 @@ package com.kdjj.presentation.viewmodel.recipesummary
 import androidx.lifecycle.*
 import com.kdjj.domain.model.Recipe
 import com.kdjj.domain.model.RecipeState
+import com.kdjj.domain.model.RecipeType
 import com.kdjj.domain.model.request.*
 import com.kdjj.domain.usecase.FlowUseCase
 import com.kdjj.domain.usecase.ResultUseCase
@@ -25,6 +26,7 @@ class RecipeSummaryViewModel @Inject constructor(
     private val saveLocalRecipeUseCase: ResultUseCase<SaveLocalRecipeRequest, Boolean>,
     private val uploadRecipeUseCase: ResultUseCase<UploadRecipeRequest, Unit>,
     private val increaseViewCountUseCase: ResultUseCase<IncreaseRemoteRecipeViewCountRequest, Unit>,
+    private val fetchRecipeTypeListUseCase: ResultUseCase<EmptyRequest, List<RecipeType>>,
     private val idGenerator: IdGenerator
 ) : ViewModel() {
 
@@ -89,6 +91,7 @@ class RecipeSummaryViewModel @Inject constructor(
         else {
             _liveLoading.value = true
             collectJob = viewModelScope.launch {
+                fetchRecipeTypeListUseCase(EmptyRequest)
                 when (recipeState) {
                     RecipeState.CREATE,
                     RecipeState.UPLOAD,


### PR DESCRIPTION
## 개요
Issue #135

## 하고자 했던 것
- 내 레시피가 비어있는 상태에서 훔쳐오기 했을 때 crash 나는 문제 해결

## 변경 사항
- [x] 레시피 개요 화면에서 RecipeType 받아오는 기능 추가

## 발생한 이슈
