### PR TITLE
[develop] Event sealed class 생성하여 Event LiveData 단일화

### DIFF
--- a/presentation/src/main/java/com/kdjj/presentation/view/home/my/MyRecipeFragment.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/home/my/MyRecipeFragment.kt
@@ -68,29 +68,30 @@ class MyRecipeFragment : Fragment() {
     }
 
     private fun setObservers() {
-        viewModel.eventAddRecipeHasPressed.observe(viewLifecycleOwner, EventObserver {
-            navigation.navigate(R.id.action_myRecipeFragment_to_recipeEditorActivity)
-        })
-
-        viewModel.eventSearchIconClicked.observe(viewLifecycleOwner, EventObserver {
-            navigation.navigate(R.id.action_myRecipeFragment_to_searchRecipeFragment)
-        })
-
-        viewModel.eventItemDoubleClicked.observe(viewLifecycleOwner, EventObserver {
-            val bundle = bundleOf(
-                RECIPE_ID to it.recipe.recipeId,
-                RECIPE_STATE to it.recipe.state
-            )
-            navigation.navigate(R.id.action_myRecipeFragment_to_recipeSummaryActivity, bundle)
-        })
-
-        viewModel.eventDataLoadFailed.observe(viewLifecycleOwner, EventObserver {
-            Snackbar.make(binding.root, getString(R.string.dataLoadFailMessage), Snackbar.LENGTH_LONG)
-                .setAction(getString(R.string.refresh)){
-                     viewModel.refreshRecipeList()
+        viewModel.eventMyRecipe.observe(viewLifecycleOwner, EventObserver{
+            when(it){
+                is MyRecipeViewModel.MyRecipeEvent.AddRecipeHasPressed -> {
+                    navigation.navigate(R.id.action_myRecipeFragment_to_recipeEditorActivity)
                 }
-                .setActionTextColor(requireContext().getColor(R.color.blue_500))
-                .show()
+                is MyRecipeViewModel.MyRecipeEvent.DoubleClicked-> {
+                    val bundle = bundleOf(
+                        RECIPE_ID to it.item.recipe.recipeId,
+                        RECIPE_STATE to it.item.recipe.state
+                    )
+                    navigation.navigate(R.id.action_myRecipeFragment_to_recipeSummaryActivity, bundle)
+                }
+                is MyRecipeViewModel.MyRecipeEvent.DataLoadFailed ->{
+                    Snackbar.make(binding.root, getString(R.string.dataLoadFailMessage), Snackbar.LENGTH_LONG)
+                        .setAction(getString(R.string.refresh)){
+                            viewModel.refreshRecipeList()
+                        }
+                        .setActionTextColor(requireContext().getColor(R.color.blue_500))
+                        .show()
+                }
+                is MyRecipeViewModel.MyRecipeEvent.SearchIconClicked -> {
+                    navigation.navigate(R.id.action_myRecipeFragment_to_searchRecipeFragment)
+                }
+            }
         })
     }
 

--- a/presentation/src/main/java/com/kdjj/presentation/view/home/my/MyRecipeFragment.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/home/my/MyRecipeFragment.kt
@@ -68,21 +68,28 @@ class MyRecipeFragment : Fragment() {
     }
 
     private fun setObservers() {
-        viewModel.eventMyRecipe.observe(viewLifecycleOwner, EventObserver{
-            when(it){
+        viewModel.eventMyRecipe.observe(viewLifecycleOwner, EventObserver {
+            when (it) {
                 is MyRecipeViewModel.MyRecipeEvent.AddRecipeHasPressed -> {
                     navigation.navigate(R.id.action_myRecipeFragment_to_recipeEditorActivity)
                 }
-                is MyRecipeViewModel.MyRecipeEvent.DoubleClicked-> {
+                is MyRecipeViewModel.MyRecipeEvent.DoubleClicked -> {
                     val bundle = bundleOf(
                         RECIPE_ID to it.item.recipe.recipeId,
                         RECIPE_STATE to it.item.recipe.state
                     )
-                    navigation.navigate(R.id.action_myRecipeFragment_to_recipeSummaryActivity, bundle)
+                    navigation.navigate(
+                        R.id.action_myRecipeFragment_to_recipeSummaryActivity,
+                        bundle
+                    )
                 }
-                is MyRecipeViewModel.MyRecipeEvent.DataLoadFailed ->{
-                    Snackbar.make(binding.root, getString(R.string.dataLoadFailMessage), Snackbar.LENGTH_LONG)
-                        .setAction(getString(R.string.refresh)){
+                is MyRecipeViewModel.MyRecipeEvent.DataLoadFailed -> {
+                    Snackbar.make(
+                        binding.root,
+                        getString(R.string.dataLoadFailMessage),
+                        Snackbar.LENGTH_LONG
+                    )
+                        .setAction(getString(R.string.refresh)) {
                             viewModel.refreshRecipeList()
                         }
                         .setActionTextColor(requireContext().getColor(R.color.blue_500))
@@ -119,7 +126,8 @@ class MyRecipeFragment : Fragment() {
             addOnScrollListener(object : RecyclerView.OnScrollListener() {
                 override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
                     super.onScrolled(recyclerView, dx, dy)
-                    val lastVisibleItemPosition = (layoutManager as LinearLayoutManager).findLastCompletelyVisibleItemPosition()
+                    val lastVisibleItemPosition =
+                        (layoutManager as LinearLayoutManager).findLastCompletelyVisibleItemPosition()
                     val lastItemPosition = myRecipeAdapter.itemCount - 1
                     if (lastVisibleItemPosition == lastItemPosition && myRecipeAdapter.itemCount != 0 && dy > 0) {
                         viewModel.fetchRecipeList(lastVisibleItemPosition)

--- a/presentation/src/main/java/com/kdjj/presentation/view/home/others/OthersRecipeFragment.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/home/others/OthersRecipeFragment.kt
@@ -45,13 +45,31 @@ class OthersRecipeFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        observeNetworkEvent()
-        observeMoveToSearchEvent()
-        observeRecipeItemClickEvent()
+        setObserver()
         setAdapter()
         setSwipeRefreshLayout()
         setBinding()
         initToolBar()
+    }
+
+    private fun setObserver() {
+        viewModel.eventOtherRecipe.observe(viewLifecycleOwner, EventObserver {
+            when (it) {
+                is OthersViewModel.OtherRecipeEvent.RecipeItemClicked -> {
+                    val bundle = bundleOf(
+                        RECIPE_ID to it.item.recipeId,
+                        RECIPE_STATE to it.item.state
+                    )
+                    navigation.navigate(R.id.action_othersFragment_to_recipeSummaryActivity, bundle)
+                }
+                is OthersViewModel.OtherRecipeEvent.SearchIconClicked -> {
+                    navigation.navigate(R.id.action_othersFragment_to_searchRecipeFragment)
+                }
+                is OthersViewModel.OtherRecipeEvent.ShowSnackBar -> {
+                    showSnackBar(getString(it.error.stringRes))
+                }
+            }
+        })
     }
 
     private fun setBinding() {
@@ -65,8 +83,8 @@ class OthersRecipeFragment : Fragment() {
         binding.toolbarOthers.apply {
             title = getString(R.string.others)
             inflateMenu(R.menu.toolbar_menu_search_item)
-            setOnMenuItemClickListener{
-                when(it.itemId){
+            setOnMenuItemClickListener {
+                when (it.itemId) {
                     R.id.item_search -> {
                         viewModel.moveToRecipeSearchFragment()
                         true
@@ -89,7 +107,8 @@ class OthersRecipeFragment : Fragment() {
                     super.onScrolled(recyclerView, dx, dy)
 
                     recyclerViewOthersRecipe.adapter?.let { adapter ->
-                        val lastVisibleItemPosition = (recyclerViewOthersRecipe.layoutManager as LinearLayoutManager).findLastCompletelyVisibleItemPosition()
+                        val lastVisibleItemPosition =
+                            (recyclerViewOthersRecipe.layoutManager as LinearLayoutManager).findLastCompletelyVisibleItemPosition()
                         val lastItemPosition = adapter.itemCount - 1
                         if (lastVisibleItemPosition == lastItemPosition && adapter.itemCount != 0 && dy > 0) {
                             this@OthersRecipeFragment.viewModel.fetchNextRecipeListPage(false)
@@ -107,28 +126,6 @@ class OthersRecipeFragment : Fragment() {
                 swipeRefreshLayoutOthers.isRefreshing = false
             }
         }
-    }
-
-    private fun observeNetworkEvent() {
-        viewModel.eventShowSnackBar.observe(viewLifecycleOwner, EventObserver {
-            showSnackBar(getString(it.stringRes))
-        })
-    }
-
-    private fun observeMoveToSearchEvent() {
-        viewModel.eventSearchIconClicked.observe(viewLifecycleOwner, EventObserver {
-            navigation.navigate(R.id.action_othersFragment_to_searchRecipeFragment)
-        })
-    }
-
-    private fun observeRecipeItemClickEvent() {
-        viewModel.eventRecipeItemClicked.observe(viewLifecycleOwner, EventObserver {
-            val bundle = bundleOf(
-                RECIPE_ID to it.recipeId,
-                RECIPE_STATE to it.state
-            )
-            navigation.navigate(R.id.action_othersFragment_to_recipeSummaryActivity, bundle)
-        })
     }
 
     private fun showSnackBar(msg: String) {

--- a/presentation/src/main/java/com/kdjj/presentation/view/recipedetail/RecipeDetailActivity.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/recipedetail/RecipeDetailActivity.kt
@@ -89,38 +89,6 @@ class RecipeDetailActivity : AppCompatActivity() {
     }
 
     private fun setObservers() {
-        viewModel.eventOpenTimer.observe(this, EventObserver {
-            AnimatorSet().apply {
-                playTogether(
-                    ObjectAnimator.ofFloat(
-                        binding.recyclerViewDetailTimer, View.TRANSLATION_Y, displayConverter.dpToPx(-50), 0f
-                    ),
-                    ObjectAnimator.ofFloat(
-                        binding.recyclerViewDetailTimer, View.ALPHA, 0f, 1f
-                    )
-                )
-                duration = 500
-                start()
-            }
-        })
-
-        viewModel.eventCloseTimer.observe(this, EventObserver { onAnimationEnd ->
-            AnimatorSet().apply {
-                playTogether(
-                    ObjectAnimator.ofFloat(
-                        binding.recyclerViewDetailTimer, View.TRANSLATION_Y, 0f, displayConverter.dpToPx(-50)
-                    ),
-                    ObjectAnimator.ofFloat(
-                        binding.recyclerViewDetailTimer, View.ALPHA, 1f, 0f
-                    )
-                )
-                duration = 500
-                doOnEnd {
-                    onAnimationEnd()
-                }
-                start()
-            }
-        })
 
         viewModel.liveLoading.observe(this) { doLoading ->
             if (doLoading) {
@@ -130,18 +98,55 @@ class RecipeDetailActivity : AppCompatActivity() {
             }
         }
 
-        viewModel.eventError.observe(this, EventObserver {
-            ConfirmDialogBuilder.create(
-                this,
-                "오류 발생",
-                "레시피를 들고오던 라따뚜이가 넘어졌습니다..ㅠㅠ\n확인버튼을 누르면 이전 화면으로 돌아갑니다."
-            ) {
-                finish()
-            }
-        })
-
         viewModel.liveTitle.observe(this) {
             title = it
         }
+
+        viewModel.eventRecipeDetail.observe(this, EventObserver {
+            when(it){
+                is RecipeDetailViewModel.RecipeDetailEvent.OpenTimer -> {
+                    AnimatorSet().apply {
+                        playTogether(
+                            ObjectAnimator.ofFloat(
+                                binding.recyclerViewDetailTimer, View.TRANSLATION_Y, displayConverter.dpToPx(-50), 0f
+                            ),
+                            ObjectAnimator.ofFloat(
+                                binding.recyclerViewDetailTimer, View.ALPHA, 0f, 1f
+                            )
+                        )
+                        duration = 500
+                        start()
+                    }
+                }
+
+                is RecipeDetailViewModel.RecipeDetailEvent.CloseTimer -> {
+                    AnimatorSet().apply {
+                        playTogether(
+                            ObjectAnimator.ofFloat(
+                                binding.recyclerViewDetailTimer, View.TRANSLATION_Y, 0f, displayConverter.dpToPx(-50)
+                            ),
+                            ObjectAnimator.ofFloat(
+                                binding.recyclerViewDetailTimer, View.ALPHA, 1f, 0f
+                            )
+                        )
+                        duration = 500
+                        doOnEnd { _ ->
+                            it.onAnimationEnd()
+                        }
+                        start()
+                    }
+                }
+
+                is RecipeDetailViewModel.RecipeDetailEvent.Error -> {
+                    ConfirmDialogBuilder.create(
+                        this,
+                        "오류 발생",
+                        "레시피를 들고오던 라따뚜이가 넘어졌습니다..ㅠㅠ\n확인버튼을 누르면 이전 화면으로 돌아갑니다."
+                    ) {
+                        finish()
+                    }
+                }
+            }
+        })
     }
 }

--- a/presentation/src/main/java/com/kdjj/presentation/view/recipeeditor/RecipeEditorActivity.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/recipeeditor/RecipeEditorActivity.kt
@@ -123,27 +123,10 @@ class RecipeEditorActivity : AppCompatActivity() {
     }
 
     private fun setupObservers() {
+
         viewModel.liveImgTarget.observe(this) { model ->
             model?.let { showSelectImageDialog() }
         }
-
-        viewModel.eventSaveResult.observe(this, EventObserver { isSuccess ->
-            if (isSuccess) {
-                ConfirmDialogBuilder.create(
-                    this,
-                    "저장 완료",
-                    "레시피가 정상적으로 저장되었습니다.",
-                ) {
-                    finish()
-                }
-            } else {
-                ConfirmDialogBuilder.create(
-                    this,
-                    "저장 실패",
-                    "레시피를 저장하지 못했습니다.",
-                ) { }
-            }
-        })
 
         viewModel.liveLoading.observe(this) { doLoading ->
             if (doLoading) {
@@ -153,13 +136,35 @@ class RecipeEditorActivity : AppCompatActivity() {
             }
         }
 
-        viewModel.eventError.observe(this, EventObserver {
-            ConfirmDialogBuilder.create(
-                this,
-                "오류 발생",
-                "레시피를 들고오던 라따뚜이가 넘어졌습니다..ㅠㅠ\n확인버튼을 누르면 이전 화면으로 돌아갑니다."
-            ) {
-                finish()
+        viewModel.eventRecipeEditor.observe(this, EventObserver {
+            when(it){
+                is RecipeEditorViewModel.RecipeEditorEvent.SaveResult -> {
+                    if (it.isSuccess) {
+                        ConfirmDialogBuilder.create(
+                            this,
+                            "저장 완료",
+                            "레시피가 정상적으로 저장되었습니다.",
+                        ) {
+                            finish()
+                        }
+                    } else {
+                        ConfirmDialogBuilder.create(
+                            this,
+                            "저장 실패",
+                            "레시피를 저장하지 못했습니다.",
+                        ) { }
+                    }
+                }
+
+                is RecipeEditorViewModel.RecipeEditorEvent.Error -> {
+                    ConfirmDialogBuilder.create(
+                        this,
+                        "오류 발생",
+                        "레시피를 들고오던 라따뚜이가 넘어졌습니다..ㅠㅠ\n확인버튼을 누르면 이전 화면으로 돌아갑니다."
+                    ) {
+                        finish()
+                    }
+                }
             }
         })
     }

--- a/presentation/src/main/java/com/kdjj/presentation/view/recipesummary/RecipeSummaryActivity.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/recipesummary/RecipeSummaryActivity.kt
@@ -2,6 +2,7 @@ package com.kdjj.presentation.view.recipesummary
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -71,77 +72,10 @@ class RecipeSummaryActivity : AppCompatActivity() {
     }
     
     private fun initObserver() = with(recipeSummaryViewModel) {
-        eventLoadError.observe(this@RecipeSummaryActivity, EventObserver {
-            ConfirmDialogBuilder.create(
-                this@RecipeSummaryActivity,
-                "오류 발생",
-                "레시피를 들고오던 라따뚜이가 넘어졌습니다..ㅠㅠ\n확인버튼을 누르면 이전 화면으로 돌아갑니다."
-            ) {
-                finish()
-            }
-        })
-        
+
         liveRecipe.observe(this@RecipeSummaryActivity) { recipe ->
             title = recipe.title
         }
-        
-        eventInitView.observe(this@RecipeSummaryActivity, EventObserver { recipeSummaryType ->
-            val menuButtonList = floatingMenuIdListMap[recipeSummaryType]?.map {
-                findViewById<AppCompatButton>(it)
-            }
-            initFloatingMenuVisibility(menuButtonList)
-        })
-        
-        eventOpenRecipeDetail.observe(this@RecipeSummaryActivity, EventObserver { recipe ->
-            val intent = Intent(
-                this@RecipeSummaryActivity,
-                RecipeDetailActivity::class.java
-            ).apply {
-                putExtra(RECIPE_ID, recipe.recipeId)
-                putExtra(RECIPE_STATE, recipe.state)
-            }
-            startActivity(intent)
-        })
-        
-        eventOpenRecipeEditor.observe(this@RecipeSummaryActivity, EventObserver { recipe ->
-            val intent = Intent(
-                this@RecipeSummaryActivity,
-                RecipeEditorActivity::class.java
-            ).apply {
-                putExtra(RECIPE_ID, recipe.recipeId)
-                putExtra(RECIPE_STATE, recipe.state)
-            }
-            startActivity(intent)
-        })
-        
-        eventDeleteFinish.observe(this@RecipeSummaryActivity, EventObserver { isSuccess ->
-            if (isSuccess) {
-                ConfirmDialogBuilder.create(
-                    this@RecipeSummaryActivity,
-                    "삭제 완료",
-                    "레시피가 정상적으로 삭제되었습니다.\n확인을 눌러 이전화면으로 돌아가주세요."
-                ) {
-                    finish()
-                }
-            } else {
-                showSnackBar("삭제 실패")
-            }
-        })
-        
-        eventUploadFinish.observe(this@RecipeSummaryActivity, EventObserver { isSuccess ->
-            val message = if (isSuccess) "업로드 성공" else "업로드 실패"
-            showSnackBar(message)
-        })
-        
-        eventSaveFinish.observe(this@RecipeSummaryActivity, EventObserver { isSuccess ->
-            val message = if (isSuccess) "저장 성공" else "저장 실패"
-            showSnackBar(message)
-        })
-        
-        eventUpdateFavoriteFinish.observe(this@RecipeSummaryActivity, EventObserver { isSuccess ->
-            val message = if (isSuccess) "즐겨찾기 추가 / 제거 성공" else "즐겨찾기 추가 / 제거 실패"
-            showSnackBar(message)
-        })
 
         liveLoading.observe(this@RecipeSummaryActivity) { doLoading ->
             if (doLoading) {
@@ -150,6 +84,79 @@ class RecipeSummaryActivity : AppCompatActivity() {
                 loadingDialog.dismiss()
             }
         }
+
+        eventRecipeSummary.observe(this@RecipeSummaryActivity, EventObserver{
+            when(it){
+                is RecipeSummaryViewModel.RecipeSummaryEvent.LoadError -> {
+                    ConfirmDialogBuilder.create(
+                        this@RecipeSummaryActivity,
+                        "오류 발생",
+                        "레시피를 들고오던 라따뚜이가 넘어졌습니다..ㅠㅠ\n확인버튼을 누르면 이전 화면으로 돌아갑니다."
+                    ) {
+                        finish()
+                    }
+                }
+
+                is RecipeSummaryViewModel.RecipeSummaryEvent.InitView -> {
+                    Log.d("aaa", it.type.toString())
+                    val menuButtonList = floatingMenuIdListMap[it.type]?.map{ id ->
+                        findViewById<AppCompatButton>(id)
+                    }
+                    initFloatingMenuVisibility(menuButtonList)
+                }
+
+                is RecipeSummaryViewModel.RecipeSummaryEvent.OpenRecipeDetail -> {
+                    val intent = Intent(
+                        this@RecipeSummaryActivity,
+                        RecipeDetailActivity::class.java
+                    ).apply {
+                        putExtra(RECIPE_ID, it.item.recipeId)
+                        putExtra(RECIPE_STATE, it.item.state)
+                    }
+                    startActivity(intent)
+                }
+
+                is RecipeSummaryViewModel.RecipeSummaryEvent.OpenRecipeEditor -> {
+                    val intent = Intent(
+                        this@RecipeSummaryActivity,
+                        RecipeEditorActivity::class.java
+                    ).apply {
+                        putExtra(RECIPE_ID, it.item.recipeId)
+                        putExtra(RECIPE_STATE, it.item.state)
+                    }
+                    startActivity(intent)
+                }
+
+                is RecipeSummaryViewModel.RecipeSummaryEvent.DeleteFinish -> {
+                    if (it.flag) {
+                        ConfirmDialogBuilder.create(
+                            this@RecipeSummaryActivity,
+                            "삭제 완료",
+                            "레시피가 정상적으로 삭제되었습니다.\n확인을 눌러 이전화면으로 돌아가주세요."
+                        ) {
+                            finish()
+                        }
+                    } else {
+                        showSnackBar("삭제 실패")
+                    }
+                }
+
+                is RecipeSummaryViewModel.RecipeSummaryEvent.UploadFinish -> {
+                    val message = if (it.flag) "업로드 성공" else "업로드 실패"
+                    showSnackBar(message)
+                }
+
+                is RecipeSummaryViewModel.RecipeSummaryEvent.SaveFinish -> {
+                    val message = if (it.flag) "저장 성공" else "저장 실패"
+                    showSnackBar(message)
+                }
+
+                is RecipeSummaryViewModel.RecipeSummaryEvent.UpdateFavoriteFinish -> {
+                    val message = if (it.flag) "즐겨찾기 추가 / 제거 성공" else "즐겨찾기 추가 / 제거 실패"
+                    showSnackBar(message)
+                }
+            }
+        })
     }
     
     private fun initFloatingMenuVisibility(buttonList: List<AppCompatButton>?) = with(binding) {

--- a/presentation/src/main/java/com/kdjj/presentation/view/recipesummary/RecipeSummaryActivity.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/recipesummary/RecipeSummaryActivity.kt
@@ -69,8 +69,9 @@ class RecipeSummaryActivity : AppCompatActivity() {
         
         initViewModel()
         initObserver()
+        initEventObserver()
     }
-    
+
     private fun initObserver() = with(recipeSummaryViewModel) {
 
         liveRecipe.observe(this@RecipeSummaryActivity) { recipe ->
@@ -84,7 +85,9 @@ class RecipeSummaryActivity : AppCompatActivity() {
                 loadingDialog.dismiss()
             }
         }
+    }
 
+    private fun initEventObserver() = with(recipeSummaryViewModel){
         eventRecipeSummary.observe(this@RecipeSummaryActivity, EventObserver{
             when(it){
                 is RecipeSummaryViewModel.RecipeSummaryEvent.LoadError -> {
@@ -158,7 +161,7 @@ class RecipeSummaryActivity : AppCompatActivity() {
             }
         })
     }
-    
+
     private fun initFloatingMenuVisibility(buttonList: List<AppCompatButton>?) = with(binding) {
         allFloatingButtonList.map { buttonId ->
             findViewById<AppCompatButton>(buttonId)

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/others/OthersViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/others/OthersViewModel.kt
@@ -41,15 +41,6 @@ class OthersViewModel @Inject constructor(
         _liveFetchLock.value = false
     }
 
-    private var _eventShowSnackBar = MutableLiveData<Event<ResponseError>>()
-    val eventShowSnackBar: LiveData<Event<ResponseError>> get() = _eventShowSnackBar
-
-    private var _eventSearchIconClicked = MutableLiveData<Event<Unit>>()
-    val eventSearchIconClicked: LiveData<Event<Unit>> get() = _eventSearchIconClicked
-
-    private var _eventRecipeItemClicked = MutableLiveData<Event<RecipeListItemModel>>()
-    val eventRecipeItemClicked: LiveData<Event<RecipeListItemModel>> get() = _eventRecipeItemClicked
-
     private var _eventOtherRecipe = MutableLiveData<Event<OtherRecipeEvent>>()
     val eventOtherRecipe: LiveData<Event<OtherRecipeEvent>> get() = _eventOtherRecipe
 

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/others/OthersViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/others/OthersViewModel.kt
@@ -50,6 +50,15 @@ class OthersViewModel @Inject constructor(
     private var _eventRecipeItemClicked = MutableLiveData<Event<RecipeListItemModel>>()
     val eventRecipeItemClicked: LiveData<Event<RecipeListItemModel>> get() = _eventRecipeItemClicked
 
+    private var _eventOtherRecipe = MutableLiveData<Event<OtherRecipeEvent>>()
+    val eventOtherRecipe: LiveData<Event<OtherRecipeEvent>> get() = _eventOtherRecipe
+
+    sealed class OtherRecipeEvent {
+        class ShowSnackBar(val error: ResponseError) : OtherRecipeEvent()
+        object SearchIconClicked : OtherRecipeEvent()
+        class RecipeItemClicked(val item: RecipeListItemModel) : OtherRecipeEvent()
+    }
+
     init {
         setChecked(OthersSortType.LATEST)
     }
@@ -121,23 +130,27 @@ class OthersViewModel @Inject constructor(
             _liveFetchLock.value = false
             when (it) {
                 is NetworkException -> {
-                    _eventShowSnackBar.value = Event(ResponseError.NETWORK_CONNECTION)
+                    _eventOtherRecipe.value =
+                        Event(OtherRecipeEvent.ShowSnackBar(ResponseError.NETWORK_CONNECTION))
                 }
                 is ApiException -> {
-                    _eventShowSnackBar.value = Event(ResponseError.SERVER)
+                    _eventOtherRecipe.value =
+                        Event(OtherRecipeEvent.ShowSnackBar(ResponseError.SERVER))
                 }
-                is CancellationException -> {}
-                else -> _eventShowSnackBar.value = Event(ResponseError.UNKNOWN)
+                is CancellationException -> {
+                }
+                else -> _eventOtherRecipe.value =
+                    Event(OtherRecipeEvent.ShowSnackBar(ResponseError.UNKNOWN))
             }
         }
     }
 
     fun moveToRecipeSearchFragment() {
-        _eventSearchIconClicked.value = Event(Unit)
+        _eventOtherRecipe.value = Event(OtherRecipeEvent.SearchIconClicked)
     }
 
     fun recipeItemClick(recipeModel: RecipeListItemModel) {
-        _eventRecipeItemClicked.value = Event(recipeModel)
+        _eventOtherRecipe.value = Event(OtherRecipeEvent.RecipeItemClicked(recipeModel))
     }
 
     enum class OthersSortType {


### PR DESCRIPTION
## 개요
각 ViewModel 내부에 Event를 위한 LiveData가 많아져 Event를 위한 LiveData를 하나만 생성하고, 각 뷰모델에서 Event sealed class를 생성해 처리

## 하고자 했던 것
- [x] MyRecipeViewModel 적용
- [x] OthersRecipeViewModel 적용
- [x] SearchRecipeViewModel 적용
- [x] RecipeSummaryViewModel 적용
- [x] RecipeEditorViewModel 적용
- [x] RecipeDetailViewModel 적용

## 변경 사항
Activity혹은 Fragment에서 각각의 LiveData를 Observe 하다가 Evnet를 관찰하는 관찰잘 하나에서 분기처리해 처리

## 발생한 이슈
