### PR TITLE
[develop, domain] WorkManager를 이용한 작업 예약 #183

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,6 +50,10 @@ dependencies {
     implementation "com.google.dagger:hilt-android:$hilt_version"
     kapt "com.google.dagger:hilt-android-compiler:$hilt_version"
 
+    implementation 'androidx.hilt:hilt-work:1.0.0'
+    // When using Kotlin.
+    kapt 'androidx.hilt:hilt-compiler:1.0.0'
+
     implementation project(path: ':data')
     implementation project(path: ':domain')
     implementation project(path: ':remote')

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.kdjj.ratatouille">
 
     <application
@@ -19,6 +20,16 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/kdjj/ratatouille/app/App.kt
+++ b/app/src/main/java/com/kdjj/ratatouille/app/App.kt
@@ -1,7 +1,19 @@
 package com.kdjj.ratatouille.app
 
 import android.app.Application
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
 import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
 
 @HiltAndroidApp
-class App : Application()
+class App : Application(), Configuration.Provider {
+
+    @Inject
+    lateinit var workerFactory: HiltWorkerFactory
+
+    override fun getWorkManagerConfiguration(): Configuration =
+        Configuration.Builder()
+            .setWorkerFactory(workerFactory)
+            .build()
+}

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
         mockito_inline_version="2.13.0"
         mockito_version="3.12.4"
         nav_version = "2.3.5"
+        work_version = "2.7.0"
     }
     repositories {
         google()

--- a/domain/src/main/java/com/kdjj/domain/model/request/UpdateRemoteRecipeRequest.kt
+++ b/domain/src/main/java/com/kdjj/domain/model/request/UpdateRemoteRecipeRequest.kt
@@ -1,7 +1,5 @@
 package com.kdjj.domain.model.request
 
-import com.kdjj.domain.model.Recipe
-
 data class UpdateRemoteRecipeRequest(
-    val recipe: Recipe
+    val recipeId: String
 ) : Request

--- a/domain/src/main/java/com/kdjj/domain/usecase/UpdateRemoteRecipeUseCase.kt
+++ b/domain/src/main/java/com/kdjj/domain/usecase/UpdateRemoteRecipeUseCase.kt
@@ -12,7 +12,7 @@ class UpdateRemoteRecipeUseCase @Inject constructor(
     
     override suspend fun invoke(request: UpdateRemoteRecipeRequest): Result<Unit> =
         runCatching {
-            val recipe = request.recipe
+            val recipe = recipeRepository.getLocalRecipe(request.recipeId).getOrThrow()
             val recipeImageUri = when (recipe.imgPath.isNotEmpty()) {
                 true -> {
                     recipeImageRepository.convertInternalUriToRemoteStorageUri(recipe.imgPath)

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -34,7 +34,7 @@ android {
         jvmTarget = '1.8'
     }
 
-    buildFeatures{
+    buildFeatures {
         viewBinding = true
         dataBinding = true
     }
@@ -81,6 +81,12 @@ dependencies {
 
     implementation 'io.reactivex.rxjava3:rxandroid:3.0.0'
     implementation 'io.reactivex.rxjava3:rxjava:3.1.2'
+
+    // WorkManager
+    implementation "androidx.work:work-runtime-ktx:$work_version"
+    implementation 'androidx.hilt:hilt-work:1.0.0'
+    // When using Kotlin.
+    kapt 'androidx.hilt:hilt-compiler:1.0.0'
 
     implementation project(path: ':domain')
 }

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     package="com.kdjj.presentation">
 
     <uses-permission
@@ -33,17 +32,6 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/fileprovider" />
         </provider>
-        <provider
-            android:name="androidx.startup.InitializationProvider"
-            android:authorities="${applicationId}.androidx-startup"
-            android:exported="false"
-            tools:node="merge">
-            <meta-data
-                android:name="androidx.work.WorkManagerInitializer"
-                android:value="androidx.startup"
-                tools:node="remove" />
-        </provider>
-
     </application>
 
 </manifest>

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.kdjj.presentation">
 
     <uses-permission
@@ -32,6 +33,17 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/fileprovider" />
         </provider>
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
+
     </application>
 
 </manifest>

--- a/presentation/src/main/java/com/kdjj/presentation/common/Utils.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/common/Utils.kt
@@ -5,6 +5,7 @@ import com.kdjj.domain.model.Recipe
 
 const val RECIPE_ID = "recipeID"
 const val RECIPE_STATE = "recipeState"
+const val UPDATED_RECIPE_ID = "updatedRecipeId"
 
 internal fun calculateSeconds(min: Int, sec: Int): Int {
     return min * 60 + sec

--- a/presentation/src/main/java/com/kdjj/presentation/di/PresentationModule.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/di/PresentationModule.kt
@@ -3,6 +3,7 @@ package com.kdjj.presentation.di
 import android.content.Context
 import android.media.Ringtone
 import android.media.RingtoneManager
+import androidx.work.WorkManager
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -20,4 +21,9 @@ class PresentationModule {
             RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
         )
     }
+
+    @Provides
+    fun provideWorkManager(
+        @ApplicationContext context: Context
+    ) = WorkManager.getInstance(context.applicationContext)
 }

--- a/presentation/src/main/java/com/kdjj/presentation/di/PresentationModule.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/di/PresentationModule.kt
@@ -25,5 +25,5 @@ class PresentationModule {
     @Provides
     fun provideWorkManager(
         @ApplicationContext context: Context
-    ) = WorkManager.getInstance(context.applicationContext)
+    ) = WorkManager.getInstance(context)
 }

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipeeditor/RecipeEditorViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipeeditor/RecipeEditorViewModel.kt
@@ -183,6 +183,7 @@ internal class RecipeEditorViewModel @Inject constructor(
     }
 
     private fun registerUploadTask(updatedRecipeId: String) {
+        workManager.cancelAllWorkByTag(updatedRecipeId)
         val constraints = Constraints.Builder()
             .setRequiredNetworkType(NetworkType.CONNECTED)
             .build()
@@ -190,6 +191,7 @@ internal class RecipeEditorViewModel @Inject constructor(
             setInputData(workDataOf(UPDATED_RECIPE_ID to updatedRecipeId))
         }
             .setConstraints(constraints)
+            .addTag(updatedRecipeId)
             .build()
         workManager.enqueue(updateWorkerRequest)
     }

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipeeditor/RecipeEditorViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipeeditor/RecipeEditorViewModel.kt
@@ -2,10 +2,8 @@ package com.kdjj.presentation.viewmodel.recipeeditor
 
 import androidx.lifecycle.*
 import com.kdjj.domain.model.Recipe
-import com.kdjj.domain.model.RecipeState
 import com.kdjj.domain.model.RecipeStepType
 import com.kdjj.domain.model.RecipeType
-import com.kdjj.domain.model.exception.UploadException
 import com.kdjj.domain.model.request.*
 import com.kdjj.domain.usecase.FlowUseCase
 import com.kdjj.domain.usecase.ResultUseCase
@@ -165,19 +163,18 @@ internal class RecipeEditorViewModel @Inject constructor(
                     _liveStepModelList.value ?: listOf(),
                     liveRecipeTypes.value ?: emptyList()
                 )
-                val res = if (isEditing) updateLocalRecipeUseCase(UpdateLocalRecipeRequest(recipe))
-                          else saveRecipeUseCase(SaveLocalRecipeRequest(recipe))
+                val res = if (isEditing) {
+                    updateLocalRecipeUseCase(UpdateLocalRecipeRequest(recipe))
+                } else {
+                    saveRecipeUseCase(SaveLocalRecipeRequest(recipe))
+                }
                 res.onSuccess {
                     _eventRecipeEditor.value =
                         Event(RecipeEditorEvent.SaveResult(true))
                 }.onFailure {
-                    it.printStackTrace()
-                    if (it is UploadException) {
-                        //worker manager
-                    } else {
-                        _eventRecipeEditor.value =
-                            Event(RecipeEditorEvent.SaveResult(false))
-                    }
+                    _eventRecipeEditor.value =
+                        Event(RecipeEditorEvent.SaveResult(false))
+
                 }
                 _liveLoading.value = false
             }

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipeeditor/RecipeEditorViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipeeditor/RecipeEditorViewModel.kt
@@ -1,9 +1,7 @@
 package com.kdjj.presentation.viewmodel.recipeeditor
 
 import androidx.lifecycle.*
-import androidx.work.OneTimeWorkRequestBuilder
-import androidx.work.WorkManager
-import androidx.work.workDataOf
+import androidx.work.*
 import com.kdjj.domain.model.Recipe
 import com.kdjj.domain.model.RecipeState
 import com.kdjj.domain.model.RecipeStepType
@@ -185,13 +183,14 @@ internal class RecipeEditorViewModel @Inject constructor(
     }
 
     private fun registerUploadTask(updatedRecipeId: String) {
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
         val updateWorkerRequest = OneTimeWorkRequestBuilder<RecipeUploadWorker>().apply {
-            setInputData(
-                workDataOf(
-                    UPDATED_RECIPE_ID to updatedRecipeId
-                )
-            )
-        }.build()
+            setInputData(workDataOf(UPDATED_RECIPE_ID to updatedRecipeId))
+        }
+            .setConstraints(constraints)
+            .build()
         workManager.enqueue(updateWorkerRequest)
     }
 

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipeeditor/RecipeUploadWorker.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipeeditor/RecipeUploadWorker.kt
@@ -1,0 +1,24 @@
+package com.kdjj.presentation.viewmodel.recipeeditor
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.kdjj.domain.model.request.UpdateRemoteRecipeRequest
+import com.kdjj.domain.usecase.ResultUseCase
+import com.kdjj.presentation.common.UPDATED_RECIPE_ID
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+
+@HiltWorker
+class RecipeUploadWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val updateRemoteRecipeUseCase: ResultUseCase<UpdateRemoteRecipeRequest, Unit>,
+) : CoroutineWorker(appContext, workerParams) {
+    override suspend fun doWork(): Result {
+        val updatedRecipeId = inputData.getString(UPDATED_RECIPE_ID) ?: return Result.failure()
+        val result = updateRemoteRecipeUseCase(UpdateRemoteRecipeRequest(updatedRecipeId))
+        return if (result.isSuccess) Result.success() else Result.retry()
+    }
+}

--- a/remote/src/main/java/com/kdjj/remote/di/RemoteModule.kt
+++ b/remote/src/main/java/com/kdjj/remote/di/RemoteModule.kt
@@ -4,8 +4,6 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.firestore.ktx.firestoreSettings
 import com.google.firebase.ktx.Firebase
-import com.google.firebase.ktx.options
-import com.google.firebase.storage.FirebaseStorage
 import com.google.firebase.storage.StorageReference
 import com.google.firebase.storage.ktx.storage
 import dagger.Module
@@ -17,7 +15,9 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object RemoteModule {
-    
+
+    private const val MAX_DELAY_TIME = 5000L
+
     @Provides
     @Singleton
     fun provideFireStore(): FirebaseFirestore {
@@ -31,5 +31,12 @@ object RemoteModule {
 
     @Provides
     @Singleton
-    fun provideFirebaseStorage(): StorageReference = Firebase.storage.reference
+    fun provideFirebaseStorage(): StorageReference {
+        val fireStorage = Firebase.storage.apply {
+            maxDownloadRetryTimeMillis = MAX_DELAY_TIME
+            maxOperationRetryTimeMillis = MAX_DELAY_TIME
+            maxUploadRetryTimeMillis = MAX_DELAY_TIME
+        }
+        return fireStorage.reference
+    }
 }


### PR DESCRIPTION
## 개요
Issue #183

## 하고자 했던 것
- WorkManager를 이용하여 유저가 업로드한 레시피가 수정될 경우 FireStore에 올리는 기능 구현
- 만약, 네트워크 연결이 되어있지 않은 경우 연결된 후 작업하도록 설정

## 변경 사항
- [x] RecipeEditorViewModel에 WorkManager를 이용한 레시피 업데이트 기능 추가
- [x] UpdateLocalRecipeUseCase Upload 하는 로직 삭제
- [x] UpdateRemoteRecipeRequest recipe -> recipeId를 받도록 변경

## 발생한 이슈
