### PR TITLE
[develop] 클릭 throttle 처리 

### DIFF
--- a/presentation/src/main/java/com/kdjj/presentation/view/home/my/MyRecipeFragment.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/home/my/MyRecipeFragment.kt
@@ -36,6 +36,11 @@ class MyRecipeFragment : Fragment() {
     @Inject
     lateinit var displayConverter: DisplayConverter
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setObservers()
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -50,7 +55,6 @@ class MyRecipeFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initToolBar()
-        setObservers()
         initSwipeRefreshLayout()
         initRecyclerView()
     }

--- a/presentation/src/main/java/com/kdjj/presentation/view/home/my/MyRecipeFragment.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/home/my/MyRecipeFragment.kt
@@ -1,6 +1,7 @@
 package com.kdjj.presentation.view.home.my
 
 import android.os.Bundle
+import android.util.Log
 import android.view.*
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
@@ -147,5 +148,10 @@ class MyRecipeFragment : Fragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    override fun onDestroy() {
+        compositeDisposable.dispose()
+        super.onDestroy()
     }
 }

--- a/presentation/src/main/java/com/kdjj/presentation/view/home/others/OthersRecipeFragment.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/home/others/OthersRecipeFragment.kt
@@ -83,7 +83,7 @@ class OthersRecipeFragment : Fragment() {
     }
 
     private fun setEventObserver() {
-        viewModel.othersRecipeEvent.observe(viewLifecycleOwner, EventObserver {
+        viewModel.eventOthersRecipe.observe(viewLifecycleOwner, EventObserver {
             when (it) {
                 is OthersViewModel.OtherRecipeEvent.ShowSnackBar -> {
                     showSnackBar(getString(it.error.stringRes))

--- a/presentation/src/main/java/com/kdjj/presentation/view/home/others/OthersRecipeFragment.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/home/others/OthersRecipeFragment.kt
@@ -33,6 +33,11 @@ class OthersRecipeFragment : Fragment() {
 
     private val compositeDisposable = CompositeDisposable()
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setObserver()
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -48,7 +53,6 @@ class OthersRecipeFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        setObserver()
         setAdapter()
         setSwipeRefreshLayout()
         setBinding()

--- a/presentation/src/main/java/com/kdjj/presentation/view/home/others/OthersRecipeFragment.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/home/others/OthersRecipeFragment.kt
@@ -21,7 +21,6 @@ import com.kdjj.presentation.view.adapter.OthersRecipeListAdapter
 import com.kdjj.presentation.viewmodel.others.OthersViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import io.reactivex.rxjava3.disposables.CompositeDisposable
-import io.reactivex.rxjava3.disposables.Disposable
 import java.util.concurrent.TimeUnit
 
 @AndroidEntryPoint
@@ -33,10 +32,6 @@ class OthersRecipeFragment : Fragment() {
     private val navigation by lazy { Navigation.findNavController(binding.root) }
 
     private val compositeDisposable = CompositeDisposable()
-
-    fun Disposable.addDisposable() {
-        compositeDisposable.add(this)
-    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -79,7 +74,9 @@ class OthersRecipeFragment : Fragment() {
                         showSnackBar(getString(it.error.stringRes))
                     }
                 }
-            }.addDisposable()
+            }.also {
+                compositeDisposable.add(it)
+            }
     }
 
     private fun setBinding() {

--- a/presentation/src/main/java/com/kdjj/presentation/view/home/others/OthersRecipeFragment.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/home/others/OthersRecipeFragment.kt
@@ -14,6 +14,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.snackbar.Snackbar
 import com.kdjj.domain.model.*
 import com.kdjj.presentation.R
+import com.kdjj.presentation.common.EventObserver
 import com.kdjj.presentation.common.RECIPE_ID
 import com.kdjj.presentation.common.RECIPE_STATE
 import com.kdjj.presentation.databinding.FragmentOthersRecipeBinding
@@ -35,7 +36,7 @@ class OthersRecipeFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setObserver()
+        setButtonClickObserver()
     }
 
     override fun onCreateView(
@@ -54,33 +55,41 @@ class OthersRecipeFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setAdapter()
+        setEventObserver()
         setSwipeRefreshLayout()
         setBinding()
         initToolBar()
     }
 
-    private fun setObserver() {
+    private fun setButtonClickObserver() {
         viewModel.othersSubject
             .throttleFirst(1, TimeUnit.SECONDS)
             .subscribe {
                 when (it) {
-                    is OthersViewModel.OtherRecipeEvent.RecipeItemClicked -> {
+                    is OthersViewModel.ButtonClick.RecipeItemClicked -> {
                         val bundle = bundleOf(
                             RECIPE_ID to it.item.recipeId,
                             RECIPE_STATE to it.item.state
                         )
                         navigation.navigate(R.id.action_othersFragment_to_recipeSummaryActivity, bundle)
                     }
-                    is OthersViewModel.OtherRecipeEvent.SearchIconClicked -> {
+                    is OthersViewModel.ButtonClick.SearchIconClicked -> {
                         navigation.navigate(R.id.action_othersFragment_to_searchRecipeFragment)
-                    }
-                    is OthersViewModel.OtherRecipeEvent.ShowSnackBar -> {
-                        showSnackBar(getString(it.error.stringRes))
                     }
                 }
             }.also {
                 compositeDisposable.add(it)
             }
+    }
+
+    private fun setEventObserver() {
+        viewModel.othersRecipeEvent.observe(viewLifecycleOwner, EventObserver {
+            when (it) {
+                is OthersViewModel.OtherRecipeEvent.ShowSnackBar -> {
+                    showSnackBar(getString(it.error.stringRes))
+                }
+            }
+        })
     }
 
     private fun setBinding() {

--- a/presentation/src/main/java/com/kdjj/presentation/view/home/search/SearchRecipeFragment.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/home/search/SearchRecipeFragment.kt
@@ -45,7 +45,7 @@ class SearchRecipeFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setSubjectObserves()
+        setButtonClickObserver()
     }
 
     override fun onCreateView(
@@ -80,29 +80,28 @@ class SearchRecipeFragment : Fragment() {
         }
 
         focusInput()
-        setObservers()
+        setEventObservers()
     }
 
-    private fun setSubjectObserves() {
+    private fun setButtonClickObserver() {
         viewModel.searchSubject
             .throttleFirst(1, TimeUnit.SECONDS)
             .subscribe {
                 when (it) {
-                    is SearchViewModel.SearchRecipeEvent.Summary -> {
+                    is SearchViewModel.ButtonClick.Summary -> {
                         val bundle = bundleOf(
                             RECIPE_ID to it.item.recipeId,
                             RECIPE_STATE to it.item.state
                         )
                         navigation.navigate(R.id.action_searchFragment_to_recipeSummaryActivity, bundle)
                     }
-                    else -> {}
                 }
             }.also {
                 compositeDisposable.add(it)
             }
     }
 
-    private fun setObservers() {
+    private fun setEventObservers() {
         Observable.create<Unit> { emitter ->
             viewModel.liveKeyword.observe(viewLifecycleOwner) {
                 emitter.onNext(Unit)
@@ -134,7 +133,6 @@ class SearchRecipeFragment : Fragment() {
                         ) { }
                     }
                 }
-                else -> {}
             }
         })
 

--- a/presentation/src/main/java/com/kdjj/presentation/view/recipesummary/RecipeSummaryActivity.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/recipesummary/RecipeSummaryActivity.kt
@@ -69,11 +69,12 @@ class RecipeSummaryActivity : AppCompatActivity() {
         setSupportActionBar(binding.toolbarSummary)
 
         initViewModel()
-        initObserver()
-        initEventObserver()
+        initObservers()
+        setEventObservers()
+        setButtonClickObserver()
     }
 
-    private fun initObserver() = with(recipeSummaryViewModel) {
+    private fun initObservers() = with(recipeSummaryViewModel) {
 
         liveRecipe.observe(this@RecipeSummaryActivity) { recipe ->
             title = recipe.title
@@ -109,11 +110,11 @@ class RecipeSummaryActivity : AppCompatActivity() {
         }
     }
 
-    private fun initEventObserver() = with(recipeSummaryViewModel) {
+    private fun setButtonClickObserver() = with(recipeSummaryViewModel) {
         summarySubject.throttleFirst(1, TimeUnit.SECONDS)
             .subscribe {
                 when (it) {
-                    is RecipeSummaryViewModel.RecipeSummaryEvent.OpenRecipeDetail -> {
+                    is RecipeSummaryViewModel.ButtonClick.OpenRecipeDetail -> {
                         val intent = Intent(
                             this@RecipeSummaryActivity,
                             RecipeDetailActivity::class.java
@@ -124,7 +125,7 @@ class RecipeSummaryActivity : AppCompatActivity() {
                         startActivity(intent)
                     }
 
-                    is RecipeSummaryViewModel.RecipeSummaryEvent.OpenRecipeEditor -> {
+                    is RecipeSummaryViewModel.ButtonClick.OpenRecipeEditor -> {
                         val intent = Intent(
                             this@RecipeSummaryActivity,
                             RecipeEditorActivity::class.java
@@ -138,7 +139,9 @@ class RecipeSummaryActivity : AppCompatActivity() {
             }.also {
                 compositeDisposable.add(it)
             }
+    }
 
+    private fun setEventObservers() = with(recipeSummaryViewModel) {
         eventRecipeSummary.observe(this@RecipeSummaryActivity, EventObserver {
             when (it) {
                 is RecipeSummaryViewModel.RecipeSummaryEvent.LoadError -> {

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/my/MyRecipeViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/my/MyRecipeViewModel.kt
@@ -54,7 +54,7 @@ internal class MyRecipeViewModel @Inject constructor(
 
     private var job: Job? = null
 
-    private var _eventMyRecipe = MutableLiveData<Event<MyRecipeEvent>>()
+    private val _eventMyRecipe = MutableLiveData<Event<MyRecipeEvent>>()
     val eventMyRecipe: LiveData<Event<MyRecipeEvent>> get() = _eventMyRecipe
 
     val mySubject: PublishSubject<ButtonClick> = PublishSubject.create()

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/my/MyRecipeViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/my/MyRecipeViewModel.kt
@@ -5,10 +5,10 @@ import com.kdjj.domain.model.Recipe
 import com.kdjj.domain.model.request.*
 import com.kdjj.domain.usecase.FlowUseCase
 import com.kdjj.domain.usecase.ResultUseCase
-import com.kdjj.presentation.common.Event
 import com.kdjj.presentation.model.MyRecipeItem
 import com.kdjj.presentation.model.SortType
 import dagger.hilt.android.lifecycle.HiltViewModel
+import io.reactivex.rxjava3.subjects.PublishSubject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collect
@@ -53,8 +53,7 @@ internal class MyRecipeViewModel @Inject constructor(
 
     private var job: Job? = null
 
-    private val _eventMyRecipe = MutableLiveData<Event<MyRecipeEvent>>()
-    val eventMyRecipe: LiveData<Event<MyRecipeEvent>> get() = _eventMyRecipe
+    val mySubject: PublishSubject<MyRecipeEvent> = PublishSubject.create()
 
     sealed class MyRecipeEvent {
         object AddRecipeHasPressed : MyRecipeEvent()
@@ -108,7 +107,7 @@ internal class MyRecipeViewModel @Inject constructor(
                 }
             }.onFailure {
                 if (it !is CancellationException) {
-                    _eventMyRecipe.value = Event(MyRecipeEvent.DataLoadFailed)
+                    mySubject.onNext(MyRecipeEvent.DataLoadFailed)
                 }
             }
             _liveFetching.value = false
@@ -119,15 +118,15 @@ internal class MyRecipeViewModel @Inject constructor(
         if (_liveRecipeItemSelected.value != selectedRecipe) {
             _liveRecipeItemSelected.value = selectedRecipe
         } else {
-            _eventMyRecipe.value = Event(MyRecipeEvent.DoubleClicked(selectedRecipe))
+            mySubject.onNext(MyRecipeEvent.DoubleClicked(selectedRecipe))
         }
     }
 
     fun moveToRecipeEditorActivity() {
-        _eventMyRecipe.value = Event(MyRecipeEvent.AddRecipeHasPressed)
+        mySubject.onNext(MyRecipeEvent.AddRecipeHasPressed)
     }
 
     fun moveToRecipeSearchFragment() {
-        _eventMyRecipe.value = Event(MyRecipeEvent.SearchIconClicked)
+        mySubject.onNext(MyRecipeEvent.SearchIconClicked)
     }
 }

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/my/MyRecipeViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/my/MyRecipeViewModel.kt
@@ -5,6 +5,7 @@ import com.kdjj.domain.model.Recipe
 import com.kdjj.domain.model.request.*
 import com.kdjj.domain.usecase.FlowUseCase
 import com.kdjj.domain.usecase.ResultUseCase
+import com.kdjj.presentation.common.Event
 import com.kdjj.presentation.model.MyRecipeItem
 import com.kdjj.presentation.model.SortType
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -53,13 +54,19 @@ internal class MyRecipeViewModel @Inject constructor(
 
     private var job: Job? = null
 
-    val mySubject: PublishSubject<MyRecipeEvent> = PublishSubject.create()
+    private var _eventMyRecipe = MutableLiveData<Event<MyRecipeEvent>>()
+    val eventMyRecipe: LiveData<Event<MyRecipeEvent>> get() = _eventMyRecipe
+
+    val mySubject: PublishSubject<ButtonClick> = PublishSubject.create()
 
     sealed class MyRecipeEvent {
-        object AddRecipeHasPressed : MyRecipeEvent()
-        class DoubleClicked(val item: MyRecipeItem.MyRecipe) : MyRecipeEvent()
-        object SearchIconClicked : MyRecipeEvent()
         object DataLoadFailed : MyRecipeEvent()
+    }
+
+    sealed class ButtonClick {
+        object AddRecipeHasPressed : ButtonClick()
+        class DoubleClicked(val item: MyRecipeItem.MyRecipe) : ButtonClick()
+        object SearchIconClicked : ButtonClick()
     }
 
     init {
@@ -107,7 +114,7 @@ internal class MyRecipeViewModel @Inject constructor(
                 }
             }.onFailure {
                 if (it !is CancellationException) {
-                    mySubject.onNext(MyRecipeEvent.DataLoadFailed)
+                    _eventMyRecipe.value = Event(MyRecipeEvent.DataLoadFailed)
                 }
             }
             _liveFetching.value = false
@@ -118,15 +125,15 @@ internal class MyRecipeViewModel @Inject constructor(
         if (_liveRecipeItemSelected.value != selectedRecipe) {
             _liveRecipeItemSelected.value = selectedRecipe
         } else {
-            mySubject.onNext(MyRecipeEvent.DoubleClicked(selectedRecipe))
+            mySubject.onNext(ButtonClick.DoubleClicked(selectedRecipe))
         }
     }
 
     fun moveToRecipeEditorActivity() {
-        mySubject.onNext(MyRecipeEvent.AddRecipeHasPressed)
+        mySubject.onNext(ButtonClick.AddRecipeHasPressed)
     }
 
     fun moveToRecipeSearchFragment() {
-        mySubject.onNext(MyRecipeEvent.SearchIconClicked)
+        mySubject.onNext(ButtonClick.SearchIconClicked)
     }
 }

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/others/OthersViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/others/OthersViewModel.kt
@@ -44,8 +44,8 @@ class OthersViewModel @Inject constructor(
 
     val othersSubject: PublishSubject<ButtonClick> = PublishSubject.create()
 
-    private var _othersRecipeEvent = MutableLiveData<Event<OtherRecipeEvent>>()
-    val othersRecipeEvent: LiveData<Event<OtherRecipeEvent>> get() = _othersRecipeEvent
+    private var _eventOthersRecipe = MutableLiveData<Event<OtherRecipeEvent>>()
+    val eventOthersRecipe: LiveData<Event<OtherRecipeEvent>> get() = _eventOthersRecipe
 
     sealed class OtherRecipeEvent {
         class ShowSnackBar(val error: ResponseError) : OtherRecipeEvent()
@@ -127,14 +127,14 @@ class OthersViewModel @Inject constructor(
             _liveFetchLock.value = false
             when (it) {
                 is NetworkException -> {
-                    _othersRecipeEvent.value = Event(OtherRecipeEvent.ShowSnackBar(ResponseError.NETWORK_CONNECTION))
+                    _eventOthersRecipe.value = Event(OtherRecipeEvent.ShowSnackBar(ResponseError.NETWORK_CONNECTION))
                 }
                 is ApiException -> {
-                    _othersRecipeEvent.value = Event(OtherRecipeEvent.ShowSnackBar(ResponseError.SERVER))
+                    _eventOthersRecipe.value = Event(OtherRecipeEvent.ShowSnackBar(ResponseError.SERVER))
                 }
                 is CancellationException -> {
                 }
-                else -> _othersRecipeEvent.value = Event(OtherRecipeEvent.ShowSnackBar(ResponseError.UNKNOWN))
+                else -> _eventOthersRecipe.value = Event(OtherRecipeEvent.ShowSnackBar(ResponseError.UNKNOWN))
 
             }
         }

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipesummary/RecipeSummaryViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipesummary/RecipeSummaryViewModel.kt
@@ -47,12 +47,15 @@ class RecipeSummaryViewModel @Inject constructor(
 
     sealed class RecipeSummaryEvent {
         object LoadError : RecipeSummaryEvent()
-        class OpenRecipeDetail(val item: Recipe) : RecipeSummaryEvent()
-        class OpenRecipeEditor(val item: Recipe) : RecipeSummaryEvent()
         class DeleteFinish(val flag: Boolean) : RecipeSummaryEvent()
         class UploadFinish(val flag: Boolean) : RecipeSummaryEvent()
         class SaveFinish(val flag: Boolean) : RecipeSummaryEvent()
         class UpdateFavoriteFinish(val flag: Boolean) : RecipeSummaryEvent()
+    }
+
+    sealed class ButtonClick {
+        class OpenRecipeDetail(val item: Recipe) : ButtonClick()
+        class OpenRecipeEditor(val item: Recipe) : ButtonClick()
     }
 
     enum class FabClick {
@@ -69,7 +72,7 @@ class RecipeSummaryViewModel @Inject constructor(
 
     private val compositeDisposable = CompositeDisposable()
     val fabClickSubject: PublishSubject<FabClick> = PublishSubject.create()
-    val summarySubject: PublishSubject<RecipeSummaryEvent> = PublishSubject.create()
+    val summarySubject: PublishSubject<ButtonClick> = PublishSubject.create()
 
     init {
         fabClickSubject.throttleFirst(1, TimeUnit.SECONDS)
@@ -251,13 +254,13 @@ class RecipeSummaryViewModel @Inject constructor(
 
     fun openRecipeDetail() {
         liveRecipe.value?.let { recipe ->
-            summarySubject.onNext(RecipeSummaryEvent.OpenRecipeDetail(recipe))
+            summarySubject.onNext(ButtonClick.OpenRecipeDetail(recipe))
         }
     }
 
     fun openRecipeEditor() {
         liveRecipe.value?.let { recipe ->
-            summarySubject.onNext(RecipeSummaryEvent.OpenRecipeEditor(recipe))
+            summarySubject.onNext(ButtonClick.OpenRecipeEditor(recipe))
         }
     }
 

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/search/SearchViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/search/SearchViewModel.kt
@@ -1,5 +1,6 @@
 package com.kdjj.presentation.viewmodel.search
 
+import android.view.SearchEvent
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -18,6 +19,7 @@ import com.kdjj.presentation.model.ResponseError
 import com.kdjj.presentation.model.SearchTabState
 import com.kdjj.presentation.model.toRecipeListItemModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import io.reactivex.rxjava3.subjects.PublishSubject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collect
@@ -51,6 +53,8 @@ class SearchViewModel @Inject constructor(
 
     private val _eventSearchRecipe = MutableLiveData<Event<SearchRecipeEvent>>()
     val eventSearchRecipe: LiveData<Event<SearchRecipeEvent>> get() = _eventSearchRecipe
+
+    val searchSubject: PublishSubject<SearchRecipeEvent> = PublishSubject.create()
 
     sealed class SearchRecipeEvent {
         class Exception(val error: ResponseError) : SearchRecipeEvent()
@@ -173,7 +177,7 @@ class SearchViewModel @Inject constructor(
     }
 
     fun moveToSummary(recipeModel: RecipeListItemModel) {
-        _eventSearchRecipe.value = Event(SearchRecipeEvent.Summary(recipeModel))
+        searchSubject.onNext(SearchRecipeEvent.Summary(recipeModel))
     }
 
 

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/search/SearchViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/search/SearchViewModel.kt
@@ -1,6 +1,5 @@
 package com.kdjj.presentation.viewmodel.search
 
-import android.view.SearchEvent
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -54,11 +53,14 @@ class SearchViewModel @Inject constructor(
     private val _eventSearchRecipe = MutableLiveData<Event<SearchRecipeEvent>>()
     val eventSearchRecipe: LiveData<Event<SearchRecipeEvent>> get() = _eventSearchRecipe
 
-    val searchSubject: PublishSubject<SearchRecipeEvent> = PublishSubject.create()
+    val searchSubject: PublishSubject<ButtonClick> = PublishSubject.create()
 
     sealed class SearchRecipeEvent {
         class Exception(val error: ResponseError) : SearchRecipeEvent()
-        class Summary(val item: RecipeListItemModel) : SearchRecipeEvent()
+    }
+
+    sealed class ButtonClick {
+        class Summary(val item: RecipeListItemModel) : ButtonClick()
     }
 
     init {
@@ -177,7 +179,7 @@ class SearchViewModel @Inject constructor(
     }
 
     fun moveToSummary(recipeModel: RecipeListItemModel) {
-        searchSubject.onNext(SearchRecipeEvent.Summary(recipeModel))
+        searchSubject.onNext(ButtonClick.Summary(recipeModel))
     }
 
 

--- a/presentation/src/main/res/layout/activity_recipe_editor.xml
+++ b/presentation/src/main/res/layout/activity_recipe_editor.xml
@@ -4,6 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+        <import type="com.kdjj.presentation.viewmodel.recipeeditor.RecipeEditorViewModel.ButtonClick"/>
+
         <variable
             name="viewModel"
             type="com.kdjj.presentation.viewmodel.recipeeditor.RecipeEditorViewModel" />
@@ -53,7 +55,7 @@
                 android:focusable="true"
                 android:gravity="center"
                 android:padding="@dimen/bottomButton_padding"
-                android:onClick="@{() -> viewModel.saveRecipe()}"
+                android:onClick="@{() -> viewModel.editorSubject.onNext(ButtonClick.SAVE)}"
                 android:text="@string/registerRecipe"
                 android:textColor="@color/light_100"
                 android:textSize="@dimen/bottomButton_textSize" />

--- a/presentation/src/main/res/layout/activity_recipe_summary.xml
+++ b/presentation/src/main/res/layout/activity_recipe_summary.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
-
+        <import type="com.kdjj.presentation.viewmodel.recipesummary.RecipeSummaryViewModel.FabClick"/>
         <variable
             name="viewModel"
             type="com.kdjj.presentation.viewmodel.recipesummary.RecipeSummaryViewModel" />
@@ -152,7 +152,7 @@
             android:id="@+id/button_summary_favorite"
             style="@style/SummaryFloatingButton"
             android:drawableEnd="@drawable/ic_star_white_16dp"
-            android:onClick="@{() -> viewModel.updateRecipeFavorite()}"
+            android:onClick="@{() -> viewModel.fabClickSubject.onNext(FabClick.UpdateRecipeFavorite)}"
             android:text="@{viewModel.liveRecipe.favorite == true ? @string/cancelFavorite : @string/registFavorite}"
             app:layout_constraintBottom_toTopOf="@id/button_summary_edit"
             app:layout_constraintEnd_toEndOf="@id/floatingActionButton_summary" />
@@ -171,7 +171,7 @@
             style="@style/SummaryFloatingButton"
             android:drawableEnd="@drawable/ic_trash_white_16dp"
             android:elevation="8dp"
-            android:onClick="@{() -> viewModel.deleteRecipe()}"
+            android:onClick="@{() -> viewModel.fabClickSubject.onNext(FabClick.DeleteRecipe)}"
             android:text="@string/delete"
             app:layout_constraintBottom_toTopOf="@id/button_summary_upload"
             app:layout_constraintEnd_toEndOf="@id/floatingActionButton_summary" />
@@ -180,7 +180,7 @@
             android:id="@+id/button_summary_upload"
             style="@style/SummaryFloatingButton"
             android:drawableEnd="@drawable/ic_upload_white_16dp"
-            android:onClick="@{() -> viewModel.uploadRecipe()}"
+            android:onClick="@{() -> viewModel.fabClickSubject.onNext(FabClick.UploadRecipe)}"
             android:text="@string/upload"
             app:layout_constraintBottom_toTopOf="@id/button_summary_stealFavorite"
             app:layout_constraintEnd_toEndOf="@id/floatingActionButton_summary" />
@@ -189,7 +189,7 @@
             android:id="@+id/button_summary_stealFavorite"
             style="@style/SummaryFloatingButton"
             android:drawableEnd="@drawable/ic_star_white_16dp"
-            android:onClick="@{() -> viewModel.saveRecipeToLocalWithFavorite()}"
+            android:onClick="@{() -> viewModel.fabClickSubject.onNext(FabClick.SaveRecipeToLocalWithFavorite)}"
             android:text="@string/steal_favorite"
             app:layout_constraintBottom_toTopOf="@id/button_summary_steal"
             app:layout_constraintEnd_toEndOf="@id/floatingActionButton_summary" />
@@ -198,7 +198,7 @@
             android:id="@+id/button_summary_steal"
             style="@style/SummaryFloatingButton"
             android:drawableEnd="@drawable/ic_directions_walk_white_16dp"
-            android:onClick="@{() -> viewModel.saveRecipeToLocal()}"
+            android:onClick="@{() -> viewModel.fabClickSubject.onNext(FabClick.SaveRecipeToLocal)}"
             android:text="@string/steal"
             app:layout_constraintBottom_toTopOf="@id/floatingActionButton_summary"
             app:layout_constraintEnd_toEndOf="@id/floatingActionButton_summary" />

--- a/presentation/src/main/res/layout/item_editor_add_step.xml
+++ b/presentation/src/main/res/layout/item_editor_add_step.xml
@@ -4,6 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+        <import type="com.kdjj.presentation.viewmodel.recipeeditor.RecipeEditorViewModel.ButtonClick"/>
+
         <variable
             name="viewModel"
             type="com.kdjj.presentation.viewmodel.recipeeditor.RecipeEditorViewModel" />
@@ -28,7 +30,7 @@
             android:contentDescription="@string/addStepButton"
             android:clickable="true"
             android:focusable="true"
-            android:onClick="@{() -> viewModel.addRecipeStep()}"
+            android:onClick="@{() -> viewModel.editorSubject.onNext(ButtonClick.ADD_STEP)}"
             android:src="@drawable/ic_round_add_24" />
     </androidx.cardview.widget.CardView>
 </layout>

--- a/remote/src/main/java/com/kdjj/remote/common/Utils.kt
+++ b/remote/src/main/java/com/kdjj/remote/common/Utils.kt
@@ -4,6 +4,7 @@ import com.google.firebase.firestore.FirebaseFirestoreException
 import com.kdjj.domain.model.exception.ApiException
 import com.kdjj.domain.model.exception.NetworkException
 import java.lang.Exception
+import java.util.concurrent.CancellationException
 
 internal fun fireStoreExceptionToDomain(throwable: Throwable) =
     when (throwable) {
@@ -13,6 +14,7 @@ internal fun fireStoreExceptionToDomain(throwable: Throwable) =
                 else -> ApiException()
             }
         }
+        is CancellationException -> throwable
         else -> {
             Exception(throwable)
         }


### PR DESCRIPTION
## 개요
Issue: https://github.com/boostcampwm-2021/Android08-Ratatouille/issues/186
## 하고자 했던 것
중복 클릭 방지를 위한 Throttle 처리 
## 변경 사항
- [x] 내 레시피 화면 Throttle 처리 
- [x] 힐끔보기 화면 Throttle 처리
- [x] 검색 화면 Throttle 처리
- [x] 레시피 개요 화면 Throttle 처리
- [x] 레시피 등록 화면 Throttle 처리    
## 발생한 이슈
fragment 에서 navigate 로 화면 이동 후 다시 돌아오면 onViewCreate() 부터 다시 호출되어, 
PublishSubject 를 여러번 구독하게 되는 현상이 발생합니다. 
그래서 Throttle 처리할 버튼 클릭 이벤트와 나머지 이벤트를 분리하여, 
Throttle 처리할 버튼 클릭 이벤트는 onCreate() 에서 설정하도록 했습니다. 88b71083daee1bc7ee6c568a5129cc5c08214081