### PR TITLE
[develop] 레시피 삭제 전에 유저에게 한번 더 묻는 창 보여주는 기능 구현 #209

### DIFF
--- a/presentation/src/main/java/com/kdjj/presentation/view/recipesummary/RecipeSummaryActivity.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/recipesummary/RecipeSummaryActivity.kt
@@ -169,6 +169,17 @@ class RecipeSummaryActivity : AppCompatActivity() {
                     }
                 }
 
+                RecipeSummaryViewModel.RecipeSummaryEvent.DeleteConfirm -> {
+                    ConfirmDialogBuilder.create(
+                        context = this@RecipeSummaryActivity,
+                        title = "삭제 확인",
+                        content = "레시피를 삭제하면 다시 볼 수 없습니다.\n정말 삭제하시겠습니까?",
+                        showCancel = true,
+                        onCancelListener = null,
+                        onConfirmListener = { recipeSummaryViewModel.deleteRecipe() }
+                    )
+                }
+
                 is RecipeSummaryViewModel.RecipeSummaryEvent.DeleteFinish -> {
                     if (it.flag) {
                         ConfirmDialogBuilder.create(

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipesummary/RecipeSummaryViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipesummary/RecipeSummaryViewModel.kt
@@ -49,6 +49,7 @@ class RecipeSummaryViewModel @Inject constructor(
     sealed class RecipeSummaryEvent {
         object LoadError : RecipeSummaryEvent()
         class DeleteFinish(val flag: Boolean) : RecipeSummaryEvent()
+        object DeleteConfirm : RecipeSummaryEvent()
         class UploadFinish(val flag: Boolean) : RecipeSummaryEvent()
         class SaveFinish(val flag: Boolean) : RecipeSummaryEvent()
         class UpdateFavoriteFinish(val result: UpdateFavoriteResult) : RecipeSummaryEvent()
@@ -61,7 +62,7 @@ class RecipeSummaryViewModel @Inject constructor(
 
     enum class FabClick {
         UpdateRecipeFavorite,
-        DeleteRecipe,
+        RequestDeleteConfirm,
         SaveRecipeToLocal,
         SaveRecipeToLocalWithFavorite,
         UploadRecipe
@@ -82,8 +83,8 @@ class RecipeSummaryViewModel @Inject constructor(
                     FabClick.UpdateRecipeFavorite -> {
                         updateRecipeFavorite()
                     }
-                    FabClick.DeleteRecipe -> {
-                        deleteRecipe()
+                    FabClick.RequestDeleteConfirm -> {
+                        requestDeleteConfirm()
                     }
                     FabClick.SaveRecipeToLocal -> {
                         saveRecipeToLocal()
@@ -189,7 +190,11 @@ class RecipeSummaryViewModel @Inject constructor(
         }
     }
 
-    private fun deleteRecipe() {
+    private fun requestDeleteConfirm() {
+        _eventRecipeSummary.value = Event(RecipeSummaryEvent.DeleteConfirm)
+    }
+
+    fun deleteRecipe() {
         _liveLoading.value = true
         viewModelScope.launch {
             collectJob?.cancel()

--- a/presentation/src/main/res/layout/activity_recipe_summary.xml
+++ b/presentation/src/main/res/layout/activity_recipe_summary.xml
@@ -203,7 +203,7 @@
             android:id="@+id/button_summary_delete"
             style="@style/SummaryFloatingButton"
             android:drawableEnd="@drawable/ic_trash_white_16dp"
-            android:onClick="@{() -> viewModel.fabClickSubject.onNext(FabClick.DeleteRecipe)}"
+            android:onClick="@{() -> viewModel.fabClickSubject.onNext(FabClick.RequestDeleteConfirm)}"
             android:text="@string/delete"
             app:layout_constraintBottom_toTopOf="@id/button_summary_upload"
             app:layout_constraintEnd_toEndOf="@id/floatingActionButton_summary" />


### PR DESCRIPTION
## 개요
Issue #209
![Nov-25-2021 23-18-12](https://user-images.githubusercontent.com/56161518/143458172-fd368048-4b25-4333-95bf-7e7dcaada0ac.gif)

## 하고자 했던 것
- 레시피 삭제 시 유저에게 한번 묻는 기능 구현

## 변경 사항
- [x] 레시피 삭제 시 유저에게 한번 묻는 기능 구현

## 발생한 이슈
