### PR TITLE
[develop] 레시피 로딩전에 항목 보이지 않도록 수정 #214

### DIFF
--- a/presentation/src/main/res/layout/activity_recipe_summary.xml
+++ b/presentation/src/main/res/layout/activity_recipe_summary.xml
@@ -44,14 +44,27 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
 
+
+                <androidx.constraintlayout.widget.Group
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:visibility="@{viewModel.liveRecipe == null ? View.GONE : View.VISIBLE}"
+                    app:constraint_referenced_ids="textView_summary_recipeTypeLabel,
+                                                     cardView_summary_recipeType,
+                                                    textView_summary_expectedTimeLabel,
+                                                    cardView_summary_expectedTime,
+                                                    textView_summary_ingredientLabel,
+                                                     cardView_summary_ingredient,
+                                                     textView_summary_stepSummaryLabel,
+                                                     cardView_summary_stepSummary" />
+
+
                 <androidx.cardview.widget.CardView
                     android:id="@+id/cardView_summary_recipeImage"
                     android:layout_width="match_parent"
                     android:layout_height="@dimen/summary_imageView_height"
-                    android:visibility="@{!viewModel.liveRecipe.imgPath.empty ? View.VISIBLE : View.GONE}"
+                    android:visibility="@{viewModel.liveRecipe == null || viewModel.liveRecipe.imgPath.empty ? View.GONE : View.VISIBLE}"
                     app:layout_constraintStart_toStartOf="parent"
-                    android:layout_marginTop="@dimen/summary_recipeImage_marginTop"
-                    app:cardCornerRadius="@dimen/summary_recipeImage_cardCornerRadius"
                     app:layout_constraintTop_toTopOf="parent">
 
                     <ImageView

--- a/presentation/src/main/res/layout/activity_recipe_summary.xml
+++ b/presentation/src/main/res/layout/activity_recipe_summary.xml
@@ -62,6 +62,8 @@
                 <androidx.cardview.widget.CardView
                     android:id="@+id/cardView_summary_recipeImage"
                     android:layout_width="match_parent"
+                    android:layout_marginTop="@dimen/summary_recipeImage_marginTop"
+                    app:cardCornerRadius="@dimen/summary_recipeImage_cardCornerRadius"
                     android:layout_height="@dimen/summary_imageView_height"
                     android:visibility="@{viewModel.liveRecipe == null || viewModel.liveRecipe.imgPath.empty ? View.GONE : View.VISIBLE}"
                     app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
## 개요
Issue #214
![Nov-26-2021 01-59-30](https://user-images.githubusercontent.com/56161518/143479977-29e50dfe-d6e7-48ca-b8eb-eecefff69254.gif)


## 하고자 했던 것
- 레시피 로드 전 레시피 개요 항목 보이지 않도록 수정

## 변경 사항
- [x] 레시피 로드 전 레시피 개요 항목 보이지 않도록 수정
- [x] 레시피 이미지 코너 둥글게 처리하는 부분 누락된 코드 추가

## 발생한 이슈
