### PR TITLE
[develop] 삭제된 레시피 업로드 무한 요청 버그 수정 #191

### DIFF
--- a/data/src/main/java/com/kdjj/data/repository/RecipeRepositoryImpl.kt
+++ b/data/src/main/java/com/kdjj/data/repository/RecipeRepositoryImpl.kt
@@ -72,7 +72,9 @@ internal class RecipeRepositoryImpl @Inject constructor(
         return isUpdated
     }
 
-    override suspend fun getLocalRecipe(recipeId: String): Result<Recipe> {
+    override suspend fun getLocalRecipe(
+        recipeId: String
+    ): Result<Recipe> {
         return recipeLocalDataSource.getRecipe(recipeId)
     }
 }

--- a/domain/src/main/java/com/kdjj/domain/model/exception/RecipeException.kt
+++ b/domain/src/main/java/com/kdjj/domain/model/exception/RecipeException.kt
@@ -1,0 +1,5 @@
+package com.kdjj.domain.model.exception
+
+class NotExistRecipeException(
+    msg: String? = null
+) : Exception(msg ?: "Not Exist Recipe")

--- a/local/src/main/java/com/kdjj/local/dao/RecipeDao.kt
+++ b/local/src/main/java/com/kdjj/local/dao/RecipeDao.kt
@@ -28,5 +28,5 @@ internal interface RecipeDao {
     fun getRecipe(recipeId: String): Flow<RecipeDto>
 
     @Query("SELECT * FROM RecipeMeta WHERE recipeMetaId = :recipeId")
-    fun getRecipeDto(recipeId: String): RecipeDto
+    fun getRecipeDto(recipeId: String): RecipeDto?
 }

--- a/local/src/main/java/com/kdjj/local/dataSource/RecipeLocalDataSourceImpl.kt
+++ b/local/src/main/java/com/kdjj/local/dataSource/RecipeLocalDataSourceImpl.kt
@@ -4,6 +4,7 @@ import androidx.room.withTransaction
 import com.kdjj.data.datasource.RecipeLocalDataSource
 import com.kdjj.domain.common.errorMap
 import com.kdjj.domain.model.Recipe
+import com.kdjj.domain.model.exception.NotExistRecipeException
 import com.kdjj.local.database.RecipeDatabase
 import com.kdjj.local.dto.UselessImageDto
 import com.kdjj.local.dto.toDomain
@@ -111,7 +112,7 @@ internal class RecipeLocalDataSourceImpl @Inject constructor(
     ): Result<Recipe> =
         withContext(Dispatchers.IO) {
             runCatching {
-                recipeDao.getRecipeDto(recipeId).toDomain()
+                recipeDao.getRecipeDto(recipeId)?.toDomain() ?: throw NotExistRecipeException()
             }
         }
 }

--- a/local/src/main/java/com/kdjj/local/dataSource/RecipeLocalDataSourceImpl.kt
+++ b/local/src/main/java/com/kdjj/local/dataSource/RecipeLocalDataSourceImpl.kt
@@ -1,8 +1,8 @@
 package com.kdjj.local.dataSource
 
 import androidx.room.withTransaction
-import com.kdjj.domain.common.errorMap
 import com.kdjj.data.datasource.RecipeLocalDataSource
+import com.kdjj.domain.common.errorMap
 import com.kdjj.domain.model.Recipe
 import com.kdjj.local.database.RecipeDatabase
 import com.kdjj.local.dto.UselessImageDto
@@ -104,9 +104,11 @@ internal class RecipeLocalDataSourceImpl @Inject constructor(
         recipeId: String
     ): Flow<Recipe> =
         recipeDao.getRecipe(recipeId)
-                .map { it.toDomain() }
+            .map { it.toDomain() }
 
-    override suspend fun getRecipe(recipeId: String): Result<Recipe> =
+    override suspend fun getRecipe(
+        recipeId: String
+    ): Result<Recipe> =
         withContext(Dispatchers.IO) {
             runCatching {
                 recipeDao.getRecipeDto(recipeId).toDomain()

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipeeditor/RecipeUploadWorker.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipeeditor/RecipeUploadWorker.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import com.kdjj.domain.model.exception.NotExistRecipeException
 import com.kdjj.domain.model.request.UpdateUploadedRecipeRequest
 import com.kdjj.domain.usecase.ResultUseCase
 import com.kdjj.presentation.common.UPDATED_RECIPE_ID
@@ -19,6 +20,13 @@ class RecipeUploadWorker @AssistedInject constructor(
     override suspend fun doWork(): Result {
         val updatedRecipeId = inputData.getString(UPDATED_RECIPE_ID) ?: return Result.failure()
         val result = updateUploadedRecipeUseCase(UpdateUploadedRecipeRequest(updatedRecipeId))
+            .onFailure {
+                when (it) {
+                    is NotExistRecipeException -> {
+                        return Result.failure()
+                    }
+                }
+            }
         return if (result.isSuccess) Result.success() else Result.retry()
     }
 }


### PR DESCRIPTION
## 개요
Issue #191 
레시피를 가져올 때 레시피가 null일 경우 레시피가 존재하지 않는다는 에러를 발생시켜 재시도를 하지 않고 실패가 되도록 수정함.

## 하고자 했던 것
- 레시피 삭제 되었을 시 업데이트 요청을 보내지 않도록 수정

## 변경 사항
- [x]  레시피 삭제 되었을 시 업데이트 요청을 보내지 않도록 수정

## 발생한 이슈
