### PR TITLE
[develop] Notification 추가 로직 Timer Service에서 -> StepTimerModel 이동 #234

### DIFF
--- a/presentation/src/main/java/com/kdjj/presentation/common/Notifications.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/common/Notifications.kt
@@ -10,77 +10,89 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.kdjj.presentation.R
 import com.kdjj.presentation.viewmodel.recipedetail.NotificationBroadcastReceiver
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
 
-object Notifications {
+class Notifications @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
 
-    fun showAlarm(context: Context, stepId: String, stepName: String) {
-        val builder = NotificationCompat.Builder(context, ALARM_CHANNEL_ID)
-            .setSmallIcon(R.drawable.ic_notification)
-            .setContentTitle(context.getString(R.string.timerEnd, stepName))
-            .setContentText(context.getString(R.string.timerEndContent, stepName))
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-            .setContentIntent(getPendingIntent(context))
+    fun showAlarm(stepId: String, stepName: String) =
+        showAlarm(context, stepId, stepName)
 
-        NotificationManagerCompat.from(context)
-            .notify(stepId.hashCode(), builder.build())
-    }
+    fun showTimer(stepId: String, stepName: String, timeLeft: Int) =
+        showTimer(context, stepId, stepName, timeLeft)
 
-    fun showTimer(context: Context, stepId: String, stepName: String, timeLeft: Int) {
-        val builder = NotificationCompat.Builder(context, TIMER_CHANNEL_ID)
-            .setOngoing(true)
-            .setSmallIcon(R.drawable.ic_notification)
-            .setContentTitle(stepName)
-            .setContentText(String.format("%02d:%02d", timeLeft/60 , timeLeft%60))
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-            .setContentIntent(getPendingIntent(context))
+    companion object {
+        private const val ALARM_CHANNEL_ID = "ID_RATATOUILLE_ALARM"
+        private const val TIMER_CHANNEL_ID = "ID_RATATOUILLE_TIMER"
+        private const val FOREGROUND_ID = "ID_FOREGROUND"
 
-        NotificationManagerCompat.from(context)
-            .notify(stepId.hashCode(), builder.build())
-    }
+        private fun showAlarm(context: Context, stepId: String, stepName: String) {
+            val builder = NotificationCompat.Builder(context, ALARM_CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_notification)
+                .setContentTitle(context.getString(R.string.timerEnd, stepName))
+                .setContentText(context.getString(R.string.timerEndContent, stepName))
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .setContentIntent(getPendingIntent(context))
 
-    fun createForegroundNotificationBuilder(context: Context) =
-        NotificationCompat.Builder(context, FOREGROUND_ID)
-            .setSmallIcon(R.drawable.ic_notification)
-            .setContentTitle(context.getString(R.string.ratatouille))
-            .setContentText(context.getString(R.string.appIsRunning))
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-            .setContentIntent(getPendingIntent(context))
+            NotificationManagerCompat.from(context)
+                .notify(stepId.hashCode(), builder.build())
+        }
 
-    fun createChannel(context: Context) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val timerChannel = NotificationChannel(
-                TIMER_CHANNEL_ID,
-                context.getString(R.string.ratatouilleTimer),
-                NotificationManager.IMPORTANCE_LOW
-            )
-            NotificationManagerCompat.from(context).createNotificationChannel(timerChannel)
+        private fun showTimer(context: Context, stepId: String, stepName: String, timeLeft: Int) {
+            val builder = NotificationCompat.Builder(context, TIMER_CHANNEL_ID)
+                .setOngoing(true)
+                .setSmallIcon(R.drawable.ic_notification)
+                .setContentTitle(stepName)
+                .setContentText(String.format("%02d:%02d", timeLeft / 60, timeLeft % 60))
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .setContentIntent(getPendingIntent(context))
 
-            val alarmChannel = NotificationChannel(
-                ALARM_CHANNEL_ID,
-                context.getString(R.string.ratatouilleAlarm),
-                NotificationManager.IMPORTANCE_HIGH
-            )
-            NotificationManagerCompat.from(context).createNotificationChannel(alarmChannel)
+            NotificationManagerCompat.from(context)
+                .notify(stepId.hashCode(), builder.build())
+        }
 
-            val foregroundChannel = NotificationChannel(
-                FOREGROUND_ID,
-                context.getString(R.string.ratatouilleForeground),
-                NotificationManager.IMPORTANCE_HIGH
-            )
-            NotificationManagerCompat.from(context).createNotificationChannel(foregroundChannel)
+        fun createForegroundNotificationBuilder(context: Context) =
+            NotificationCompat.Builder(context, FOREGROUND_ID)
+                .setSmallIcon(R.drawable.ic_notification)
+                .setContentTitle(context.getString(R.string.ratatouille))
+                .setContentText(context.getString(R.string.appIsRunning))
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .setContentIntent(getPendingIntent(context))
+
+        fun createChannel(context: Context) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val timerChannel = NotificationChannel(
+                    TIMER_CHANNEL_ID,
+                    context.getString(R.string.ratatouilleTimer),
+                    NotificationManager.IMPORTANCE_LOW
+                )
+                NotificationManagerCompat.from(context).createNotificationChannel(timerChannel)
+
+                val alarmChannel = NotificationChannel(
+                    ALARM_CHANNEL_ID,
+                    context.getString(R.string.ratatouilleAlarm),
+                    NotificationManager.IMPORTANCE_HIGH
+                )
+                NotificationManagerCompat.from(context).createNotificationChannel(alarmChannel)
+
+                val foregroundChannel = NotificationChannel(
+                    FOREGROUND_ID,
+                    context.getString(R.string.ratatouilleForeground),
+                    NotificationManager.IMPORTANCE_HIGH
+                )
+                NotificationManagerCompat.from(context).createNotificationChannel(foregroundChannel)
+            }
+        }
+
+        fun cancelAllNotification(context: Context) {
+            NotificationManagerCompat.from(context).cancelAll()
+        }
+
+        private fun getPendingIntent(context: Context): PendingIntent {
+            val intent = Intent(context, NotificationBroadcastReceiver::class.java)
+            return PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT)
         }
     }
-
-    fun cancelAllNotification(context: Context){
-        NotificationManagerCompat.from(context).cancelAll()
-    }
-
-    private fun getPendingIntent(context: Context): PendingIntent {
-        val intent = Intent(context, NotificationBroadcastReceiver::class.java)
-        return PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT)
-    }
-
-    private const val ALARM_CHANNEL_ID = "ID_RATATOUILLE_ALARM"
-    private const val TIMER_CHANNEL_ID = "ID_RATATOUILLE_TIMER"
-    private const val FOREGROUND_ID = "ID_FOREGROUND"
 }

--- a/presentation/src/main/java/com/kdjj/presentation/common/Notifications.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/common/Notifications.kt
@@ -17,41 +17,35 @@ class Notifications @Inject constructor(
     @ApplicationContext private val context: Context
 ) {
 
-    fun showAlarm(stepId: String, stepName: String) =
-        showAlarm(context, stepId, stepName)
+     fun showTimer(stepId: String, stepName: String, timeLeft: Int) {
+        val builder = NotificationCompat.Builder(context, TIMER_CHANNEL_ID)
+            .setOngoing(true)
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentTitle(stepName)
+            .setContentText(String.format("%02d:%02d", timeLeft / 60, timeLeft % 60))
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setContentIntent(getPendingIntent(context))
 
-    fun showTimer(stepId: String, stepName: String, timeLeft: Int) =
-        showTimer(context, stepId, stepName, timeLeft)
+        NotificationManagerCompat.from(context)
+            .notify(stepId.hashCode(), builder.build())
+    }
+
+    fun showAlarm(stepId: String, stepName: String) {
+        val builder = NotificationCompat.Builder(context, ALARM_CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentTitle(context.getString(R.string.timerEnd, stepName))
+            .setContentText(context.getString(R.string.timerEndContent, stepName))
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setContentIntent(getPendingIntent(context))
+
+        NotificationManagerCompat.from(context)
+            .notify(stepId.hashCode(), builder.build())
+    }
 
     companion object {
         private const val ALARM_CHANNEL_ID = "ID_RATATOUILLE_ALARM"
         private const val TIMER_CHANNEL_ID = "ID_RATATOUILLE_TIMER"
         private const val FOREGROUND_ID = "ID_FOREGROUND"
-
-        private fun showAlarm(context: Context, stepId: String, stepName: String) {
-            val builder = NotificationCompat.Builder(context, ALARM_CHANNEL_ID)
-                .setSmallIcon(R.drawable.ic_notification)
-                .setContentTitle(context.getString(R.string.timerEnd, stepName))
-                .setContentText(context.getString(R.string.timerEndContent, stepName))
-                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-                .setContentIntent(getPendingIntent(context))
-
-            NotificationManagerCompat.from(context)
-                .notify(stepId.hashCode(), builder.build())
-        }
-
-        private fun showTimer(context: Context, stepId: String, stepName: String, timeLeft: Int) {
-            val builder = NotificationCompat.Builder(context, TIMER_CHANNEL_ID)
-                .setOngoing(true)
-                .setSmallIcon(R.drawable.ic_notification)
-                .setContentTitle(stepName)
-                .setContentText(String.format("%02d:%02d", timeLeft / 60, timeLeft % 60))
-                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-                .setContentIntent(getPendingIntent(context))
-
-            NotificationManagerCompat.from(context)
-                .notify(stepId.hashCode(), builder.build())
-        }
 
         fun createForegroundNotificationBuilder(context: Context) =
             NotificationCompat.Builder(context, FOREGROUND_ID)
@@ -86,13 +80,13 @@ class Notifications @Inject constructor(
             }
         }
 
-        fun cancelAllNotification(context: Context) {
-            NotificationManagerCompat.from(context).cancelAll()
-        }
-
         private fun getPendingIntent(context: Context): PendingIntent {
             val intent = Intent(context, NotificationBroadcastReceiver::class.java)
             return PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+        }
+
+        fun cancelAllNotification(context: Context) {
+            NotificationManagerCompat.from(context).cancelAll()
         }
     }
 }

--- a/presentation/src/main/java/com/kdjj/presentation/model/StepTimer.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/model/StepTimer.kt
@@ -6,7 +6,7 @@ class StepTimer(
     leftTimeInMillis: Long,
     private val onTickListener: (Long) -> Unit,
     private val onFinishListener: () -> Unit
-) : CountDownTimer(leftTimeInMillis, 100L) {
+) : CountDownTimer(leftTimeInMillis, 1000L) {
 
     override fun onTick(millisUntilFinished: Long) {
         onTickListener(millisUntilFinished)

--- a/presentation/src/main/java/com/kdjj/presentation/model/StepTimerModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/model/StepTimerModel.kt
@@ -56,10 +56,12 @@ class StepTimerModel (
             }
         }, {
             onFinishListener(this)
-            notifications.showAlarm(
-                recipeStep.stepId,
-                recipeStep.name
-            )
+            if(isRunningOnBackground){
+                notifications.showAlarm(
+                    recipeStep.stepId,
+                    recipeStep.name
+                )
+            }
         }).start()
         _liveState.value = TimerState.RUNNING
     }

--- a/presentation/src/main/java/com/kdjj/presentation/model/StepTimerModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/model/StepTimerModel.kt
@@ -71,8 +71,8 @@ class StepTimerModel (
         _eventAnimation.value = Event(Unit)
     }
 
-    fun onBackgroundOrForeground(){
-        isRunningOnBackground = !isRunningOnBackground
+    fun setBackground(state: Boolean){
+        isRunningOnBackground = state
     }
 
     enum class TimerState {

--- a/presentation/src/main/java/com/kdjj/presentation/services/TimerService.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/services/TimerService.kt
@@ -3,80 +3,16 @@ package com.kdjj.presentation.services
 
 import android.content.Intent
 import android.os.CountDownTimer
+import android.util.Log
 import androidx.lifecycle.LifecycleService
 import com.kdjj.presentation.common.ACTION_START
 import com.kdjj.presentation.common.Notifications
 
 class TimerService : LifecycleService() {
 
-    class ServiceTimer(
-        time: Long,
-        private val onTickListener: (Long) -> Unit,
-        private val onFinishListener: () -> Unit
-    ) : CountDownTimer(time, 1000) {
-        override fun onTick(millisUntilFinished: Long) {
-            onTickListener(millisUntilFinished)
-        }
-
-        override fun onFinish() {
-            onFinishListener()
-        }
-    }
-
-    private var serviceTimer: ServiceTimer? = null
-
-    data class StepTimerItem(val time: Int, val stepId: String, val stepName: String)
-
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         intent?.let { intent ->
             if (intent.action == ACTION_START) {
-                val timerStrList = intent.getStringArrayExtra("TIMERS") ?: arrayOf()
-
-                val timerList = timerStrList.map { timerStr ->
-                    val (timeStr, stepId, stepName) = timerStr.split(":", limit = 3)
-                    StepTimerItem(timeStr.toInt(), stepId, stepName)
-                }.sortedByDescending { it.time }
-                    .filter { it.time > 0 }
-
-                if (timerList.isEmpty()) {
-                    return@let
-                }
-
-                val checkAlarms = hashSetOf<String>()
-                val maxMillis = (timerList.maxOf { it.time }) * 1000L
-                serviceTimer = ServiceTimer(maxMillis, { millisLeft ->
-                    val timeElapsed = maxMillis - millisLeft
-                    timerList.forEach { item ->
-                        val timeLeft = (item.time - timeElapsed / 1000).toInt()
-                        if (timeLeft >= 0) {
-                            Notifications.showTimer(
-                                applicationContext,
-                                item.stepId,
-                                item.stepName,
-                                timeLeft
-                            )
-                        } else if (!checkAlarms.contains(item.stepId)) {
-                            Notifications.showAlarm(
-                                applicationContext,
-                                item.stepId,
-                                item.stepName
-                            )
-                            checkAlarms.add(item.stepId)
-                        }
-                    }
-                }) {
-                    timerList.forEach { item ->
-                        if (!checkAlarms.contains(item.stepId)) {
-                            Notifications.showAlarm(
-                                applicationContext,
-                                item.stepId,
-                                item.stepName
-                            )
-                            checkAlarms.add(item.stepId)
-                        }
-                    }
-                }.apply { start() }
-
                 startForeground(
                     FOREGROUND_NOTIFICATION_ID,
                     Notifications.createForegroundNotificationBuilder(this).build()
@@ -88,7 +24,6 @@ class TimerService : LifecycleService() {
 
     override fun onDestroy() {
         Notifications.cancelAllNotification(this)
-        serviceTimer?.cancel()
         super.onDestroy()
     }
 

--- a/presentation/src/main/java/com/kdjj/presentation/view/recipedetail/RecipeDetailActivity.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/recipedetail/RecipeDetailActivity.kt
@@ -5,7 +5,6 @@ import android.animation.ObjectAnimator
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import androidx.activity.viewModels
 import androidx.core.animation.doOnEnd
@@ -17,7 +16,6 @@ import com.kdjj.domain.model.*
 import com.kdjj.presentation.R
 import com.kdjj.presentation.common.*
 import com.kdjj.presentation.databinding.ActivityRecipeDetailBinding
-import com.kdjj.presentation.model.StepTimerModel
 import com.kdjj.presentation.services.TimerService
 import com.kdjj.presentation.view.adapter.RecipeDetailLargeStepListAdapter
 import com.kdjj.presentation.view.adapter.RecipeDetailStepListAdapter
@@ -137,7 +135,8 @@ class RecipeDetailActivity : AppCompatActivity() {
                             ObjectAnimator.ofFloat(
                                 binding.recyclerViewDetailTimer,
                                 View.TRANSLATION_Y,
-                                resources.getDimensionPixelSize(R.dimen.detail_timer_animation).toFloat(),
+                                resources.getDimensionPixelSize(R.dimen.detail_timer_animation)
+                                    .toFloat(),
                                 0f,
                             ),
                             ObjectAnimator.ofFloat(
@@ -194,6 +193,7 @@ class RecipeDetailActivity : AppCompatActivity() {
     override fun onRestart() {
         super.onRestart()
         applicationContext.stopService(Intent(applicationContext, TimerService::class.java))
+        viewModel.onBackgroundOrForeground()
     }
 
     override fun onBackPressed() {
@@ -203,16 +203,11 @@ class RecipeDetailActivity : AppCompatActivity() {
 
     override fun onStop() {
         if (!isExiting) {
-            Intent(applicationContext, TimerService::class.java).also { timerIntent ->
-                timerIntent.action = "ACTION_START"
-                val timerList = viewModel.liveTimerList.value ?: return
-                timerIntent.putExtra("TIMERS",
-                    timerList.filter { it.liveState.value == StepTimerModel.TimerState.RUNNING }.map { timer ->
-                        "${timer.liveLeftSeconds.value ?: 0}:${timer.recipeStep.stepId}:${timer.recipeStep.name}"
-                    }.toTypedArray()
-                )
-                applicationContext.startService(timerIntent)
+            val intent = Intent(applicationContext, TimerService::class.java).apply {
+                action = ACTION_START
             }
+            applicationContext.startService(intent)
+            viewModel.onBackgroundOrForeground()
         }
         super.onStop()
     }

--- a/presentation/src/main/java/com/kdjj/presentation/view/recipedetail/RecipeDetailActivity.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/view/recipedetail/RecipeDetailActivity.kt
@@ -193,7 +193,7 @@ class RecipeDetailActivity : AppCompatActivity() {
     override fun onRestart() {
         super.onRestart()
         applicationContext.stopService(Intent(applicationContext, TimerService::class.java))
-        viewModel.onBackgroundOrForeground()
+        viewModel.setBackground(false)
     }
 
     override fun onBackPressed() {
@@ -207,7 +207,7 @@ class RecipeDetailActivity : AppCompatActivity() {
                 action = ACTION_START
             }
             applicationContext.startService(intent)
-            viewModel.onBackgroundOrForeground()
+            viewModel.setBackground(true)
         }
         super.onStop()
     }

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipedetail/RecipeDetailViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipedetail/RecipeDetailViewModel.kt
@@ -162,9 +162,9 @@ class RecipeDetailViewModel @Inject constructor(
         }
     }
 
-    fun onBackgroundOrForeground(){
+    fun setBackground(state: Boolean){
         _liveTimerList.value?.forEach { stepTimerModel ->
-            stepTimerModel.onBackgroundOrForeground()
+            stepTimerModel.setBackground(state)
         }
     }
 

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipedetail/RecipeDetailViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipedetail/RecipeDetailViewModel.kt
@@ -9,6 +9,7 @@ import com.kdjj.domain.model.request.FetchOthersRecipeRequest
 import com.kdjj.domain.model.request.GetMyRecipeRequest
 import com.kdjj.domain.usecase.ResultUseCase
 import com.kdjj.presentation.common.Event
+import com.kdjj.presentation.common.Notifications
 import com.kdjj.presentation.model.StepTimerModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -18,14 +19,15 @@ import javax.inject.Inject
 class RecipeDetailViewModel @Inject constructor(
     private val ringtone: Ringtone,
     private val getMyRecipeUseCase: ResultUseCase<GetMyRecipeRequest, Recipe>,
-    private val fetchOthersRecipeUseCase: ResultUseCase<FetchOthersRecipeRequest, Recipe>
+    private val fetchOthersRecipeUseCase: ResultUseCase<FetchOthersRecipeRequest, Recipe>,
+    private val notifications: Notifications
 ) : ViewModel() {
 
     private val _liveStepList = MutableLiveData<List<RecipeStep>>()
     val liveStepList: LiveData<List<RecipeStep>> get() = _liveStepList
     val liveModelList = liveStepList.map { stepList ->
         stepList.map { step ->
-            StepTimerModel(step) {
+            StepTimerModel(step, notifications) {
                 ringtone.play()
                 _liveTimerList.value?.indexOf(it)?.let { idx ->
                     _eventRecipeDetail.value = Event(RecipeDetailEvent.MoveToTimer(idx))
@@ -157,6 +159,12 @@ class RecipeDetailViewModel @Inject constructor(
                     timerModel.reset()
                 }
             }
+        }
+    }
+
+    fun onBackgroundOrForeground(){
+        _liveTimerList.value?.forEach { stepTimerModel ->
+            stepTimerModel.onBackgroundOrForeground()
         }
     }
 


### PR DESCRIPTION
…#234

## 개요
기존에 timer가 ViewModel과 timerService 두곳에서 동작하는것을 ViewModel에서만 사용하도록 변경

## 하고자 했던 것
- [x] TimerService에 startForground를 제외한 모든 Notification 로직 삭제
- [x] object Notifications 클래스를 일반 클래스로 변경
- [x] RecipeDetailViewModel에 Notifications 주입
- [x] 기존의 Notification 추가 로직 StepTimerModel로 이동

## 변경 사항

## 발생한 이슈
