### PR TITLE
[develop] StateFlow 제거

### DIFF
--- a/data/src/main/java/com/kdjj/data/repository/RecipeRepositoryImpl.kt
+++ b/data/src/main/java/com/kdjj/data/repository/RecipeRepositoryImpl.kt
@@ -21,9 +21,7 @@ internal class RecipeRepositoryImpl @Inject constructor(
         recipe: Recipe
     ): Result<Unit> {
         return recipeLocalDataSource.saveRecipe(recipe).onSuccess {
-            coroutineScope {
-                isUpdatedFlow.emit(Unit)
-            }
+            isUpdatedFlow.emit(Unit)
         }
     }
 
@@ -31,9 +29,7 @@ internal class RecipeRepositoryImpl @Inject constructor(
         recipe: Recipe
     ): Result<Unit> {
         return recipeLocalDataSource.updateRecipe(recipe).onSuccess {
-            coroutineScope {
-                isUpdatedFlow.emit(Unit)
-            }
+            isUpdatedFlow.emit(Unit)
         }
     }
 
@@ -42,9 +38,7 @@ internal class RecipeRepositoryImpl @Inject constructor(
         originImgPathList: List<String>
     ): Result<Unit> {
         return recipeLocalDataSource.updateRecipe(recipe, originImgPathList).onSuccess {
-            coroutineScope {
-                isUpdatedFlow.emit(Unit)
-            }
+            isUpdatedFlow.emit(Unit)
         }
     }
 
@@ -52,9 +46,7 @@ internal class RecipeRepositoryImpl @Inject constructor(
         recipe: Recipe
     ): Result<Unit> {
         return recipeLocalDataSource.deleteRecipe(recipe).onSuccess {
-            coroutineScope {
-                isUpdatedFlow.emit(Unit)
-            }
+            isUpdatedFlow.emit(Unit)
         }
     }
 

--- a/data/src/main/java/com/kdjj/data/repository/RecipeRepositoryImpl.kt
+++ b/data/src/main/java/com/kdjj/data/repository/RecipeRepositoryImpl.kt
@@ -4,7 +4,9 @@ import com.kdjj.data.datasource.RecipeLocalDataSource
 import com.kdjj.data.datasource.RecipeRemoteDataSource
 import com.kdjj.domain.model.Recipe
 import com.kdjj.domain.repository.RecipeRepository
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import javax.inject.Inject
 
@@ -13,31 +15,47 @@ internal class RecipeRepositoryImpl @Inject constructor(
     private val recipeRemoteDataSource: RecipeRemoteDataSource
 ) : RecipeRepository {
 
-    private val isUpdated = MutableStateFlow(0)
+    private val isUpdatedFlow = MutableSharedFlow<Unit>(0)
 
     override suspend fun saveMyRecipe(
         recipe: Recipe
     ): Result<Unit> {
-        return recipeLocalDataSource.saveRecipe(recipe).onSuccess { isUpdated.value++ }
+        return recipeLocalDataSource.saveRecipe(recipe).onSuccess {
+            coroutineScope {
+                isUpdatedFlow.emit(Unit)
+            }
+        }
     }
 
     override suspend fun updateMyRecipe(
         recipe: Recipe
     ): Result<Unit> {
-        return recipeLocalDataSource.updateRecipe(recipe).onSuccess { isUpdated.value++ }
+        return recipeLocalDataSource.updateRecipe(recipe).onSuccess {
+            coroutineScope {
+                isUpdatedFlow.emit(Unit)
+            }
+        }
     }
 
     override suspend fun updateMyRecipe(
         recipe: Recipe,
         originImgPathList: List<String>
     ): Result<Unit> {
-        return recipeLocalDataSource.updateRecipe(recipe, originImgPathList).onSuccess { isUpdated.value++ }
+        return recipeLocalDataSource.updateRecipe(recipe, originImgPathList).onSuccess {
+            coroutineScope {
+                isUpdatedFlow.emit(Unit)
+            }
+        }
     }
 
     override suspend fun deleteMyRecipe(
         recipe: Recipe
     ): Result<Unit> {
-        return recipeLocalDataSource.deleteRecipe(recipe).onSuccess { isUpdated.value++ }
+        return recipeLocalDataSource.deleteRecipe(recipe).onSuccess {
+            coroutineScope {
+                isUpdatedFlow.emit(Unit)
+            }
+        }
     }
 
     override suspend fun uploadRecipe(
@@ -68,8 +86,8 @@ internal class RecipeRepositoryImpl @Inject constructor(
         return recipeRemoteDataSource.fetchRecipe(recipeId)
     }
 
-    override fun getRecipeUpdateFlow(): Flow<Int> {
-        return isUpdated
+    override fun getRecipeUpdateFlow(): Flow<Unit> {
+        return isUpdatedFlow
     }
 
     override suspend fun getLocalRecipe(

--- a/data/src/test/java/com/kdjj/data/repository/RecipeRepositoryImplTest.kt
+++ b/data/src/test/java/com/kdjj/data/repository/RecipeRepositoryImplTest.kt
@@ -3,7 +3,6 @@ package com.kdjj.data.repository
 import com.kdjj.data.datasource.RecipeLocalDataSource
 import com.kdjj.data.datasource.RecipeRemoteDataSource
 import com.kdjj.domain.model.*
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Test
@@ -35,13 +34,10 @@ class RecipeRepositoryImplTest {
                 .thenReturn(Result.success(Unit))
 
             // when
-            val updatedFlow = repositoryImpl.getRecipeUpdateFlow()
-            val oldUpdatedValue = updatedFlow.first()
             val result = repositoryImpl.saveMyRecipe(mockRecipe)
 
             // then
             assertTrue(result.isSuccess)
-            assertEquals(oldUpdatedValue + 1, updatedFlow.first())
         }
     }
 
@@ -53,13 +49,10 @@ class RecipeRepositoryImplTest {
                 .thenReturn(Result.failure(Exception()))
 
             // when
-            val updatedFlow = repositoryImpl.getRecipeUpdateFlow()
-            val oldUpdatedValue = updatedFlow.first()
             val result = repositoryImpl.saveMyRecipe(mockRecipe)
 
             // then
             assertTrue(result.isFailure)
-            assertEquals(oldUpdatedValue, updatedFlow.first())
         }
     }
 
@@ -71,13 +64,10 @@ class RecipeRepositoryImplTest {
                 .thenReturn(Result.success(Unit))
 
             // when
-            val updatedFlow = repositoryImpl.getRecipeUpdateFlow()
-            val oldUpdatedValue = updatedFlow.first()
             val result = repositoryImpl.updateMyRecipe(mockRecipe)
 
             // then
             assertTrue(result.isSuccess)
-            assertEquals(oldUpdatedValue + 1, updatedFlow.first())
         }
     }
 
@@ -89,13 +79,10 @@ class RecipeRepositoryImplTest {
                 .thenReturn(Result.failure(Exception()))
 
             // when
-            val updatedFlow = repositoryImpl.getRecipeUpdateFlow()
-            val oldUpdatedValue = updatedFlow.first()
             val result = repositoryImpl.updateMyRecipe(mockRecipe)
 
             // then
             assertTrue(result.isFailure)
-            assertEquals(oldUpdatedValue, updatedFlow.first())
         }
     }
 
@@ -107,13 +94,10 @@ class RecipeRepositoryImplTest {
                 .thenReturn(Result.success(Unit))
 
             // when
-            val updatedFlow = repositoryImpl.getRecipeUpdateFlow()
-            val oldUpdatedValue = updatedFlow.first()
             val result = repositoryImpl.updateMyRecipe(mockRecipe, listOf())
 
             // then
             assertTrue(result.isSuccess)
-            assertEquals(oldUpdatedValue + 1, updatedFlow.first())
         }
     }
 
@@ -125,13 +109,10 @@ class RecipeRepositoryImplTest {
                 .thenReturn(Result.failure(Exception()))
 
             // when
-            val updatedFlow = repositoryImpl.getRecipeUpdateFlow()
-            val oldUpdatedValue = updatedFlow.first()
             val result = repositoryImpl.updateMyRecipe(mockRecipe, listOf())
 
             // then
             assertTrue(result.isFailure)
-            assertEquals(oldUpdatedValue, updatedFlow.first())
         }
     }
 
@@ -143,13 +124,10 @@ class RecipeRepositoryImplTest {
                 .thenReturn(Result.success(Unit))
 
             // when
-            val updatedFlow = repositoryImpl.getRecipeUpdateFlow()
-            val oldUpdatedValue = updatedFlow.first()
             val result = repositoryImpl.deleteMyRecipe(mockRecipe)
 
             // then
             assertTrue(result.isSuccess)
-            assertEquals(oldUpdatedValue + 1, updatedFlow.first())
         }
     }
 
@@ -161,13 +139,10 @@ class RecipeRepositoryImplTest {
                 .thenReturn(Result.failure(Exception()))
 
             // when
-            val updatedFlow = repositoryImpl.getRecipeUpdateFlow()
-            val oldUpdatedValue = updatedFlow.first()
             val result = repositoryImpl.deleteMyRecipe(mockRecipe)
 
             // then
             assertTrue(result.isFailure)
-            assertEquals(oldUpdatedValue, updatedFlow.first())
         }
     }
 

--- a/domain/src/main/java/com/kdjj/domain/di/FlowUseCaseModule.kt
+++ b/domain/src/main/java/com/kdjj/domain/di/FlowUseCaseModule.kt
@@ -20,5 +20,5 @@ abstract class FlowUseCaseModule {
     @Binds
     internal abstract fun bindGetRecipeUpdateFlowUseCase(
         getRecipeUpdateFlowUseCase: GetRecipeUpdateFlowUseCase
-    ): FlowUseCase<EmptyRequest, Int>
+    ): FlowUseCase<EmptyRequest, Unit>
 }

--- a/domain/src/main/java/com/kdjj/domain/model/RecipeStepType.kt
+++ b/domain/src/main/java/com/kdjj/domain/model/RecipeStepType.kt
@@ -1,7 +1,6 @@
 package com.kdjj.domain.model
 
 enum class RecipeStepType {
-    FRY,
-    PREPARE,
-    COOK
+    COOK,
+    PREPARE
 }

--- a/domain/src/main/java/com/kdjj/domain/repository/RecipeRepository.kt
+++ b/domain/src/main/java/com/kdjj/domain/repository/RecipeRepository.kt
@@ -37,7 +37,7 @@ interface RecipeRepository {
         recipeId: String
     ): Result<Recipe>
 
-    fun getRecipeUpdateFlow(): Flow<Int>
+    fun getRecipeUpdateFlow(): Flow<Unit>
 
     suspend fun getLocalRecipe(
         recipeId: String

--- a/domain/src/main/java/com/kdjj/domain/usecase/GetRecipeUpdateFlowUseCase.kt
+++ b/domain/src/main/java/com/kdjj/domain/usecase/GetRecipeUpdateFlowUseCase.kt
@@ -7,8 +7,8 @@ import javax.inject.Inject
 
 class GetRecipeUpdateFlowUseCase @Inject constructor(
     private val recipeRepository: RecipeRepository
-) : FlowUseCase<EmptyRequest, Int> {
+) : FlowUseCase<EmptyRequest, Unit> {
 
-    override fun invoke(request: EmptyRequest): Flow<Int> =
+    override fun invoke(request: EmptyRequest): Flow<Unit> =
         recipeRepository.getRecipeUpdateFlow()
 }

--- a/domain/src/test/java/com/kdjj/domain/usecase/GetRecipeUpdateFlowUseCaseTest.kt
+++ b/domain/src/test/java/com/kdjj/domain/usecase/GetRecipeUpdateFlowUseCaseTest.kt
@@ -27,12 +27,12 @@ class GetRecipeUpdateFlowUseCaseTest {
     @Test
     fun getRecipeUpdateFlowUseCase_givenFlowInt_returnFlowInt(): Unit = runBlocking {
         //when
-        `when`(mockRecipeRepository.getRecipeUpdateFlow()).thenReturn(flowOf(1))
+        `when`(mockRecipeRepository.getRecipeUpdateFlow()).thenReturn(flowOf(Unit))
 
         //given
         val testResult = getRecipeUpdateFlowUseCase.invoke(mockEmptyRequest)
 
         //then
-        assertEquals(1, testResult.first())
+        assertEquals(Unit, testResult.first())
     }
 }

--- a/local/src/test/java/com/kdjj/local/dataSource/RecipeListLocalDataSourceImplTest.kt
+++ b/local/src/test/java/com/kdjj/local/dataSource/RecipeListLocalDataSourceImplTest.kt
@@ -38,7 +38,7 @@ class RecipeListLocalDataSourceImplTest {
         "stepId",
         "삶기",
         1,
-        RecipeStepType.FRY,
+        RecipeStepType.COOK,
         "description",
         "image path",
         1000,

--- a/local/src/test/java/com/kdjj/local/dataSource/RecipeLocalDataSourceImplTest.kt
+++ b/local/src/test/java/com/kdjj/local/dataSource/RecipeLocalDataSourceImplTest.kt
@@ -26,7 +26,7 @@ class RecipeLocalDataSourceImplTest {
         RecipeStep(
             "stepId",
             "굽기",
-            RecipeStepType.FRY,
+            RecipeStepType.COOK,
             "description",
             "image path",
             1000,
@@ -63,7 +63,7 @@ class RecipeLocalDataSourceImplTest {
         "stepId",
         "삶기",
         1,
-        RecipeStepType.FRY,
+        RecipeStepType.COOK,
         "description",
         "image path",
         1000,

--- a/local/src/test/java/com/kdjj/local/dataSource/RecipeTempLocalDataSourceImplTest.kt
+++ b/local/src/test/java/com/kdjj/local/dataSource/RecipeTempLocalDataSourceImplTest.kt
@@ -22,7 +22,7 @@ class RecipeTempLocalDataSourceImplTest {
         RecipeStep(
             "stepId",
             "굽기",
-            RecipeStepType.FRY,
+            RecipeStepType.COOK,
             "description",
             "image path",
             1000,
@@ -61,7 +61,7 @@ class RecipeTempLocalDataSourceImplTest {
         "stepId",
         "삶기",
         1,
-        RecipeStepType.FRY,
+        RecipeStepType.COOK,
         "description",
         "image path",
         1000,

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/my/MyRecipeViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/my/MyRecipeViewModel.kt
@@ -21,7 +21,7 @@ internal class MyRecipeViewModel @Inject constructor(
     private val latestRecipeUseCase: ResultUseCase<FetchMyLatestRecipeListRequest, List<Recipe>>,
     private val favoriteRecipeUseCase: ResultUseCase<FetchMyFavoriteRecipeListRequest, List<Recipe>>,
     private val titleRecipeUseCase: ResultUseCase<FetchMyTitleRecipeListRequest, List<Recipe>>,
-    private val getRecipeUpdateFlowUseCase: FlowUseCase<EmptyRequest, Int>,
+    private val getRecipeUpdateFlowUseCase: FlowUseCase<EmptyRequest, Unit>,
     private val deleteUselessImageFileUseCase: ResultUseCase<EmptyRequest, Unit>
 ) : ViewModel() {
 

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipeeditor/RecipeEditorViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipeeditor/RecipeEditorViewModel.kt
@@ -282,9 +282,13 @@ internal class RecipeEditorViewModel @Inject constructor(
     }
 
     private fun saveTempRecipe() {
-        if (_liveStepModelList.value == null || isSameWithOld()) {
+        if (
+            _liveStepModelList.value == null || isSameWithOld() ||
+            (_eventRecipeEditor.value?.peekContent() as? RecipeEditorEvent.SaveResult)?.isSuccess == true
+        ) {
             return
         }
+
         _liveTempLoading.value = true
         tempJob?.cancel()
         tempJob = viewModelScope.launch {

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipeeditor/RecipeEditorViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipeeditor/RecipeEditorViewModel.kt
@@ -90,7 +90,7 @@ internal class RecipeEditorViewModel @Inject constructor(
     private val compositeDisposable = CompositeDisposable()
     val editorSubject: PublishSubject<ButtonClick> = PublishSubject.create()
 
-    private val tempFlow = MutableStateFlow(0)
+    private val tempFlow = MutableSharedFlow<Unit>(0)
     private var oldRecipe: Recipe? = null
 
     private val _liveTempLoading = MutableLiveData(false)
@@ -122,7 +122,9 @@ internal class RecipeEditorViewModel @Inject constructor(
     }
 
     fun doEdit() {
-        tempFlow.value++
+        viewModelScope.launch {
+            tempFlow.emit(Unit)
+        }
     }
 
     private fun isSameWithOld(): Boolean {

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/search/SearchViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/search/SearchViewModel.kt
@@ -29,7 +29,7 @@ import javax.inject.Inject
 class SearchViewModel @Inject constructor(
     private val fetchMySearchUseCase: ResultUseCase<FetchMySearchRecipeListRequest, List<Recipe>>,
     private val fetchOthersSearchUseCase: ResultUseCase<FetchOthersSearchRecipeListRequest, List<Recipe>>,
-    private val getRecipeUpdateFlowUseCase: FlowUseCase<EmptyRequest, Int>
+    private val getRecipeUpdateFlowUseCase: FlowUseCase<EmptyRequest, Unit>
 ) : ViewModel() {
     private val _liveTabState = MutableLiveData(SearchTabState.OTHERS_RECIPE)
     val liveTabState: LiveData<SearchTabState> get() = _liveTabState

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/search/SearchViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/search/SearchViewModel.kt
@@ -57,6 +57,7 @@ class SearchViewModel @Inject constructor(
     val liveNoResult: LiveData<Boolean> get() = _liveNoResult
 
     private var lastKeyword = ""
+    private var lastTabState = _liveTabState.value ?: SearchTabState.OTHERS_RECIPE
 
     val searchSubject: PublishSubject<ButtonClick> = PublishSubject.create()
 
@@ -88,7 +89,7 @@ class SearchViewModel @Inject constructor(
     }
 
     fun updateSearchKeyword() {
-        if (lastKeyword == liveKeyword.value ?: "") {
+        if (lastKeyword == liveKeyword.value ?: "" && lastTabState == liveTabState.value) {
             return
         }
 
@@ -119,6 +120,7 @@ class SearchViewModel @Inject constructor(
                             }
                             _liveResultList.value = it.map(Recipe::toRecipeListItemModel)
                             lastKeyword = liveKeyword.value ?: ""
+                            lastTabState = SearchTabState.OTHERS_RECIPE
                         }
                         .onFailure { t ->
                             setException(t)
@@ -136,6 +138,7 @@ class SearchViewModel @Inject constructor(
                             }
                             _liveResultList.value = it.map(Recipe::toRecipeListItemModel)
                             lastKeyword = liveKeyword.value ?: ""
+                            lastTabState = SearchTabState.MY_RECIPE
                         }
                         .onFailure { t ->
                             setException(t)

--- a/remote/src/main/java/com/kdjj/remote/dto/RecipeStepDto.kt
+++ b/remote/src/main/java/com/kdjj/remote/dto/RecipeStepDto.kt
@@ -6,7 +6,7 @@ import com.kdjj.domain.model.RecipeStepType
 internal data class RecipeStepDto(
     val stepId: String = "",
     val name: String = "",
-    val type: RecipeStepType = RecipeStepType.FRY,
+    val type: RecipeStepType = RecipeStepType.values().first(),
     val description: String = "",
     val imgPath: String = "",
     val seconds: Int = 0

--- a/remote/src/test/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImplTest.kt
+++ b/remote/src/test/java/com/kdjj/remote/datasource/RecipeListRemoteDataSourceImplTest.kt
@@ -19,7 +19,7 @@ class RecipeListRemoteDataSourceImplTest {
     private val dummyRecipeStep1 = RecipeStep(
         stepId = "dummyStepId1",
         name = "dummyStep1",
-        type = RecipeStepType.FRY,
+        type = RecipeStepType.values().first(),
         description = "dummyStepDescription",
         imgPath = "",
         seconds = 0

--- a/remote/src/test/java/com/kdjj/remote/datasource/RecipeRemoteDataSourceImplTest.kt
+++ b/remote/src/test/java/com/kdjj/remote/datasource/RecipeRemoteDataSourceImplTest.kt
@@ -21,7 +21,7 @@ class RecipeRemoteDataSourceImplTest {
     private val dummyRecipeStep1 = RecipeStep(
         stepId = "dummyStepId1",
         name = "dummyStep1",
-        type = RecipeStepType.FRY,
+        type = RecipeStepType.values().first(),
         description = "dummyStepDescription",
         imgPath = "",
         seconds = 0


### PR DESCRIPTION
close #262 

## 개요

상태 전달을 위한 StateFlow를 제거하고 SharedFlow를 사용하요 이벤트를 발생하도록 수정

## 변경사항

- 검색 화면에서 탭 변경할 때 검색 안되는 문제 수정
- FRY 제거