### PR TITLE
[develop] 힐끔보기에서 네트워크 연결이 안되어 있을 시 개요 이동시에 무한로딩 발생 #269

### DIFF
--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipesummary/RecipeSummaryViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipesummary/RecipeSummaryViewModel.kt
@@ -130,8 +130,8 @@ class RecipeSummaryViewModel @Inject constructor(
                                         recipe
                                     )
                                 )
-                                _liveLoading.value = false
                             }
+                        _liveLoading.value = false
                     }
                 }
             }

--- a/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipesummary/RecipeSummaryViewModel.kt
+++ b/presentation/src/main/java/com/kdjj/presentation/viewmodel/recipesummary/RecipeSummaryViewModel.kt
@@ -130,6 +130,8 @@ class RecipeSummaryViewModel @Inject constructor(
                                         recipe
                                     )
                                 )
+                            }.onFailure {
+                                _eventRecipeSummary.value = Event(RecipeSummaryEvent.LoadError)
                             }
                         _liveLoading.value = false
                     }


### PR DESCRIPTION
## 개요
Issue #269
![error](https://user-images.githubusercontent.com/56161518/144697892-698e018b-4627-4455-857d-7be1fc24b6d4.gif)
 
## 하고자 했던 것
- [x] 힐끔보기에서 네트워크 연결이 안되어 있을 시 개요로 이동시에 무한로딩 하는 버그 수정

## 변경 사항
- 레시피 로드 성공, 실패와 상관없이 로딩 다이얼로그 제거하도록 수정
- 레시피 로드 실패 시 에러 다이얼로그 띄우는 기능 추가

## 발생한 이슈
